### PR TITLE
systemd: remove the network options of the kubelet

### DIFF
--- a/pkg/run/kubectl.go
+++ b/pkg/run/kubectl.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (r *Runtime) applyManifests() error {
-	glog.Infof("Calling kubectl create -f %s ...", r.env.GetManifestsABSPathToApply())
+	glog.Infof("Calling kubectl apply -f %s ...", r.env.GetManifestsABSPathToApply())
 	b, err := exec.Command(r.env.GetHyperkubePath(), "kubectl", "--kubeconfig", r.env.GetKubeconfigInsecurePath(), "apply", "-f", r.env.GetManifestsABSPathToApply()).CombinedOutput()
 	output := string(b)
 	if err != nil {

--- a/pkg/setup/systemd.go
+++ b/pkg/setup/systemd.go
@@ -205,11 +205,11 @@ func (e *Environment) createKubeletUnit() error {
 				"--hostname-override=" + e.GetHostname(),
 				"--root-dir=" + e.kubeletRootDir,
 				"--healthz-port=" + strconv.Itoa(e.GetKubeletHealthzPort()), // TODO conf this
-				"--cert-dir=" + path.Join(e.kubeletRootDir, "pki"),
+				"--cert-dir=" + path.Join(e.kubeletRootDir, "pki"),          // not used
 				"--kubeconfig=" + e.GetKubeconfigInsecurePath(),
 				`--cloud-provider=""`,
 
-				"--resolv-conf=" + e.GetResolvConfPath(), // TODO this flag is ignored
+				//"--resolv-conf=" + e.GetResolvConfPath(), // TODO this flag is ignored
 				"--cluster-dns=" + e.dnsClusterIP.String(),
 				"--cluster-domain=cluster.local",
 
@@ -226,12 +226,12 @@ func (e *Environment) createKubeletUnit() error {
 				"--authentication-token-webhook-cache-ttl=5s",
 				"--authorization-mode=Webhook",
 
-				"--cni-conf-dir=" + e.networkABSPath, // no-op if
-				"--cni-bin-dir=" + e.binABSPath,      // --network-plugin is unset
-				networkPluginArgs,
+				//"--cni-conf-dir=" + e.networkABSPath, // no-op if
+				//"--cni-bin-dir=" + e.binABSPath,      // --network-plugin is unset
+				networkPluginArgs, // TODO
 
-				"--cadvisor-port=" + config.ViperConfig.GetString("kubelet-cadvisor-port"),
-				"--cgroups-per-qos=true", // TODO
+				"--cadvisor-port=" + config.ViperConfig.GetString("kubelet-cadvisor-port"), // TODO switch to a catalog
+				"--cgroups-per-qos=true",                                                   // TODO
 				"--max-pods=110",
 				"--node-ip=" + e.outboundIP.String(),
 				"--node-labels=e2e=mononode",


### PR DESCRIPTION
### What does this PR do?

This PR removes the network configuration of the kubelet systemd unit.
These options will be restored when using the CNI plugin.

### Motivation

Avoid any confusion when downgrading the kubelet.

