### PR TITLE
Create an API ready endpoint

### DIFF
--- a/pkg/run/probe.go
+++ b/pkg/run/probe.go
@@ -1,0 +1,30 @@
+package run
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"io/ioutil"
+	"net/http"
+)
+
+func (r *Runtime) httpProbe(url string) error {
+	resp, err := r.httpClient.Get(url)
+	if err != nil {
+		glog.V(5).Infof("HTTP probe %s failed: %v", url, err)
+		return err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		glog.Errorf("Unexpected error when reading body of %s: %s", url, err)
+		return err
+	}
+	content := string(b)
+	defer resp.Body.Close()
+	glog.V(10).Infof("%s %q", url, content)
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("bad status code for %s: %d", url, resp.StatusCode)
+		glog.V(5).Infof("HTTP probe %s failed: %v", url, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/run/state.go
+++ b/pkg/run/state.go
@@ -1,0 +1,58 @@
+package run
+
+import (
+	"github.com/golang/glog"
+	"sync"
+)
+
+type State struct {
+	sync.RWMutex
+
+	apiServerProbeLastError string
+	apiServerHookDone       bool
+
+	kubeletProbeFail  int
+	kubeletPodRunning int
+}
+
+func (s *State) IsAPIServerHookDone() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.apiServerHookDone
+}
+
+func (s *State) setAPIServerHookDone() {
+	s.Lock()
+	s.apiServerHookDone = true
+	s.Unlock()
+}
+
+func (s *State) setAPIServerProbeLastError(msg string) {
+	s.Lock()
+	if s.apiServerProbeLastError != msg {
+		glog.Infof("Kubenertes apiserver not ready yet: %s", msg)
+		s.apiServerProbeLastError = msg
+	}
+	s.Unlock()
+}
+
+func (s *State) incKubeletProbeFail() {
+	s.Lock()
+	s.kubeletProbeFail++
+	s.Unlock()
+}
+
+func (s *State) getKubeletProbeFail() int {
+	s.RLock()
+	defer s.RUnlock()
+	return s.kubeletProbeFail
+}
+
+func (s *State) setKubeletPodRunning(nb int) {
+	s.Lock()
+	if s.kubeletPodRunning != nb {
+		glog.Infof("Kubelet is running %d pods", nb)
+		s.kubeletPodRunning = nb
+	}
+	s.Unlock()
+}


### PR DESCRIPTION
### What does this PR do?

Allows to query the pupernetes API to observe if the setup is ready.


**Not ready yet:**
```bash
curl 127.0.0.1:8989/ready -v
```
```text
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8989 (#0)
> GET /ready HTTP/1.1
> Host: 127.0.0.1:8989
> User-Agent: curl/7.55.1
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< Date: Sat, 21 Apr 2018 16:25:24 GMT
< Content-Length: 13
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 127.0.0.1 left intact
not ready yet
```

**Ready:**
```bash
curl 127.0.0.1:8989/ready -v
```
```text
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8989 (#0)
> GET /ready HTTP/1.1
> Host: 127.0.0.1:8989
> User-Agent: curl/7.55.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sat, 21 Apr 2018 16:17:30 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 127.0.0.1 left intact
ok
```

### Motivation

It's conveniant to know when we could trigger an `argo install`

### Additional Notes

While messing around the Run function, I refactored it.