### PR TITLE
Add an audit capability to the apiserver

### DIFF
--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -120,6 +120,9 @@ func (r *Runtime) Run() error {
 			r.runDisplay()
 
 		case <-apiserverHookChan.C:
+			if r.state.IsAPIServerHookDone() {
+				continue
+			}
 			err = r.httpProbe("http://127.0.0.1:8080/healthz")
 			if err != nil {
 				r.state.setAPIServerProbeLastError(err.Error())
@@ -132,8 +135,8 @@ func (r *Runtime) Run() error {
 				glog.Errorf("Cannot apply manifests in %s", r.env.GetManifestsABSPathToApply())
 				continue
 			}
-			glog.V(2).Infof("Kubernetes apiserver hooks done")
 			r.state.setAPIServerHookDone()
+			glog.V(2).Infof("Kubernetes apiserver hooks done")
 			apiserverHookChan.Stop()
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Provide a way to add audit logs to the apiserver. This will be useful to debug any api aggregator operation.

### Motivation

When starting to use the metrics-server, it's not easy to debug any cross communication between Kubernetes components.

### Additional Notes

At the moment, it only provides audit logs for `kubectl logs/exec` as example.

[See](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/)
