### PR TITLE
Proxy google nameservers by default

### DIFF
--- a/pkg/setup/network.go
+++ b/pkg/setup/network.go
@@ -145,8 +145,8 @@ func (e *Environment) generateResolvConf() error {
 		return err
 	}
 	if len(discoveredNameservers) == 0 {
-		glog.V(2).Infof("No nameserver discovered, adding default 8.8.8.8") // TODO remove this
-		discoveredNameservers = append(discoveredNameservers, "8.8.8.8")
+		glog.V(2).Infof("No nameserver discovered, adding default 8.8.8.8, 8.8.4.4") // TODO remove this
+		discoveredNameservers = append(discoveredNameservers, "8.8.8.8", "8.8.4.4")
 	}
 	nameservers = append(nameservers, discoveredNameservers...)
 

--- a/pkg/setup/systemd.go
+++ b/pkg/setup/systemd.go
@@ -209,7 +209,7 @@ func (e *Environment) createKubeletUnit() error {
 				"--kubeconfig=" + e.GetKubeconfigInsecurePath(),
 				`--cloud-provider=""`,
 
-				//"--resolv-conf=" + e.GetResolvConfPath(), // TODO this flag is ignored
+				"--resolv-conf=" + e.GetResolvConfPath(),
 				"--cluster-dns=" + e.dnsClusterIP.String(),
 				"--cluster-domain=cluster.local",
 

--- a/pkg/setup/templates/manifests.go
+++ b/pkg/setup/templates/manifests.go
@@ -380,7 +380,7 @@ data:
           pods insecure
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        proxy . /etc/resolv.conf 8.8.8.8 8.8.4.4
         cache 30
     }
 ---


### PR DESCRIPTION
### What does this PR do?

Allows to run pupernetes with coredns and an access to the Google nameservers.
