### PR TITLE
Can run directly in systemd from the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ check:
 	$(CC) test -v ./pkg/options/
 	$(CC) test -v ./pkg/setup/
 	$(CC) test -v ./pkg/util/
+	$(CC) test -v ./pkg/job/
 
 sha512sum: pupernetes
 	$@ ./$^ > $^.$@

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ sudo systemctl list-units run-r*.service
 
 The `DESCRIPTION` field should match the initial `{COMMAND} [ARGS...]`
 
+### Systemd as job type
+
+It's possible to run pupernetes as a systemd service directly with the command line.
+In this case, pupernetes asks to be started with the given arguments.
+See more info about it in the [run command](docs/pupernetes_run.md).
+
+Graceful stop it with:
+
+* `systemctl stop pupernetes.service`
+* `--timeout`
+* `curl -XPOST 127.0.0.1:8989/stop`
+
 ### Command line
 
 The full documentation is available [here](docs).

--- a/docs/pupernetes.md
+++ b/docs/pupernetes.md
@@ -1,10 +1,10 @@
 ## pupernetes
 
-Use this command to manage a Kubernetes testing environment
+Use this command to clean setup and run a Kubernetes local environment
 
 ### Synopsis
 
-Use this command to manage a Kubernetes testing environment
+Use this command to clean setup and run a Kubernetes local environment
 
 ### Options
 

--- a/docs/pupernetes_clean.md
+++ b/docs/pupernetes_clean.md
@@ -48,5 +48,5 @@ pupernetes clean state/ -c etcd,network,secrets
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes testing environment
+* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
 

--- a/docs/pupernetes_run.md
+++ b/docs/pupernetes_run.md
@@ -29,16 +29,23 @@ pupernetes run state/ --timeout 5m
 # Setup and run the environment, then garantee a kubelet garbage collection during the drain phase: 
 pupernetes run state/ --gc 1m
 
+# Setup and run the environment as a systemd service:
+# Get logs with "journalctl -o cat -efu pupernetes" 
+# Get status with "systemctl status pupernetes --no-pager" 
+pupernetes run state/ --job-type systemd
+
 ```
 
 ### Options
 
 ```
-      --bind-address string   bind address for the API ip:port (default "127.0.0.1:8989")
-  -d, --drain string          drain options after run: iptables,kubeletgc,pods,all,none (default "all")
-      --gc duration           grace period for the kubelet GC trigger when draining run, no-op if not draining (default 1m0s)
-  -h, --help                  help for run
-      --timeout duration      timeout for run (default 6h0m0s)
+      --bind-address string       bind address for the API ip:port (default "127.0.0.1:8989")
+  -d, --drain string              drain options after run: iptables,kubeletgc,pods,all,none (default "all")
+      --gc duration               grace period for the kubelet GC trigger when draining run, no-op if not draining (default 1m0s)
+  -h, --help                      help for run
+      --job-type string           type of job: fg or systemd (default "fg")
+      --systemd-job-name string   unit name used when running as systemd service (default "pupernetes")
+      --timeout duration          timeout for run (default 6h0m0s)
 ```
 
 ### Options inherited from parent commands
@@ -58,5 +65,5 @@ pupernetes run state/ --gc 1m
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes testing environment
+* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
 

--- a/docs/pupernetes_setup.md
+++ b/docs/pupernetes_setup.md
@@ -39,5 +39,5 @@ pupernetes setup state/
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes testing environment
+* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,13 @@ import (
 
 var ViperConfig = viper.New()
 
+const (
+	// Job control
+	JobTypeKey    = "job-type"
+	JobSystemd    = "systemd"
+	JobForeground = "fg"
+)
+
 func init() {
 	ViperConfig.SetDefault("hyperkube-version", "1.10.1")
 	ViperConfig.SetDefault("vault-version", "0.9.5")
@@ -30,6 +37,11 @@ func init() {
 	ViperConfig.SetDefault("drain", "all")
 	ViperConfig.SetDefault("timeout", time.Hour*6)
 	ViperConfig.SetDefault("gc", time.Second*60)
+
+	// The supported job-type are "fg" and "systemd"
+	ViperConfig.SetDefault(JobTypeKey, JobForeground)
+
+	ViperConfig.SetDefault("systemd-job-name", "pupernetes")
 
 	ViperConfig.SetDefault("kubelet-cadvisor-port", 0)
 }

--- a/pkg/job/systemd.go
+++ b/pkg/job/systemd.go
@@ -1,0 +1,157 @@
+package job
+
+import (
+	"fmt"
+	"github.com/DataDog/pupernetes/pkg/config"
+	dbus2 "github.com/coreos/go-systemd/dbus"
+	"github.com/coreos/go-systemd/unit"
+	"github.com/golang/glog"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	unitPath = "/run/systemd/system/"
+)
+
+func createExecStart(givenRootPath string, argv []string, wd string) (string, error) {
+	copyArgv := make([]string, len(argv))
+	copy(copyArgv, argv)
+	if !path.IsAbs(copyArgv[0]) {
+		copyArgv[0] = path.Join(wd, copyArgv[0])
+	}
+
+	for i := 0; i < len(copyArgv); i++ {
+		if copyArgv[i] == givenRootPath && !path.IsAbs(givenRootPath) {
+			copyArgv[i] = path.Join(wd, givenRootPath)
+		}
+		// replace --job-type=systemd by --job-type=fg
+		if copyArgv[i] == fmt.Sprintf("--%s=%s", config.JobTypeKey, config.JobSystemd) {
+			copyArgv[i] = strings.Replace(copyArgv[i], config.JobSystemd, config.JobForeground, -1)
+			break
+		}
+		// replace --job-type systemd by --job-type fg
+		if copyArgv[i] != "--"+config.JobTypeKey {
+			continue
+		}
+		if copyArgv[i+1] != config.JobSystemd {
+			err := fmt.Errorf("invalid command line: %s", strings.Join(copyArgv, " "))
+			glog.Errorf("Unexpected error: %s", err)
+			return "", err
+		}
+		copyArgv[i+1] = config.JobForeground
+	}
+	return strings.Join(copyArgv, " "), nil
+}
+
+// RunSystemdJob creates and starts a systemd unit with the current command line as ExecStart
+func RunSystemdJob(givenRootPath string) error {
+	dbus, err := dbus2.NewSystemdConnection()
+	if err != nil {
+		glog.Errorf("Cannot connect to dbus: %v", err)
+		return err
+	}
+	defer dbus.Close()
+
+	unitName := config.ViperConfig.GetString("systemd-job-name")
+	if !strings.HasSuffix(unitName, ".service") {
+		unitName = unitName + ".service"
+	}
+	units, err := dbus.ListUnitsByNames([]string{unitName})
+	if err != nil {
+		glog.Errorf("Cannot get the status of %s: %v", unitName, err)
+		return err
+	}
+	for _, u := range units {
+		glog.V(3).Infof("Unit %q with load state %q is %q", u.Name, u.LoadState, u.SubState)
+		if u.SubState == "running" {
+			glog.V(2).Infof("Nothing to do: %s is already running: systemctl status %s --full", u.Name, u.Name)
+			return nil
+		}
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		glog.Errorf("Unexpected error during get current working directory: %v", err)
+		return err
+	}
+
+	execStart, err := createExecStart(givenRootPath, os.Args, wd)
+	if err != nil {
+		glog.Errorf("Cannot create ExecStart command: %v", err)
+		return err
+	}
+	glog.V(2).Infof("Creating an unit with ExecStart=%s", execStart)
+	sdP8s := []*unit.UnitOption{
+		{
+			Section: "Unit",
+			Name:    "Description",
+			Value:   "github.com/DataDog/pupernetes",
+		},
+		{
+			Section: "Unit",
+			Name:    "After",
+			Value:   "network.target",
+		},
+		{
+			Section: "Service",
+			Name:    "ExecStart",
+			Value:   execStart,
+		},
+		{
+			Section: "Service",
+			Name:    "Restart",
+			Value:   "no",
+		},
+	}
+
+	// Write the unit on disk
+	unitABSPath := path.Join(unitPath, unitName)
+	glog.V(2).Infof("Creating systemd unit %s ...", unitName)
+	c := unit.Serialize(sdP8s)
+	b, err := ioutil.ReadAll(c)
+	if err != nil {
+		glog.Errorf("Cannot create systemd unit: %v", err)
+		return err
+	}
+	err = ioutil.WriteFile(unitABSPath, b, 0444)
+	if err != nil {
+		glog.Errorf("Fail to write systemd unit %s: %v", unitABSPath, err)
+		return err
+	}
+	glog.V(2).Infof("Successfully wrote systemd unit %s", unitABSPath)
+
+	err = dbus.Reload()
+	if err != nil {
+		glog.Errorf("Failed to daemon-reload: %v", err)
+		return err
+	}
+
+	// Start the unit
+	statusChan := make(chan string)
+	defer close(statusChan)
+	_, err = dbus.StartUnit(unitName, "replace", statusChan)
+	if err != nil {
+		glog.Errorf("Cannot start %s: %v", unitName, err)
+		return err
+	}
+
+	// Poll the status of the started unit
+	timeout := time.After(time.Second * 5)
+	for {
+		select {
+		case s := <-statusChan:
+			glog.V(2).Infof("Status of %s job: %q", unitName, s)
+			if s == "done" {
+				return nil
+			}
+		case <-timeout:
+			err := fmt.Errorf("timeout awaiting for %s unit to be done", unitName)
+			glog.Errorf("Unexpected error: %v", err)
+			return err
+		}
+	}
+}

--- a/pkg/job/systemd_test.go
+++ b/pkg/job/systemd_test.go
@@ -1,0 +1,78 @@
+package job
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCreateExecStart(t *testing.T) {
+	tc := []struct {
+		givenRootPath string
+		argv          []string
+		wd            string
+		execStart     string
+	}{
+		{
+			"/opt/sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "/opt/sandbox", "--job-type", "systemd"},
+			"/",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type fg",
+		},
+		{
+			"/opt/sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "/opt/sandbox", "--job-type=systemd"},
+			"/",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg",
+		},
+		{
+			"/opt/sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "/opt/sandbox", "--job-type=systemd", "-v", "3"},
+			"/",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg -v 3",
+		},
+		{
+			"sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "sandbox", "--job-type=systemd", "-v", "3"},
+			"/opt",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg -v 3",
+		},
+		{
+			"./sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "./sandbox", "--job-type=systemd", "-v", "3"},
+			"/opt",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg -v 3",
+		},
+		{
+			"../sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "../sandbox", "--job-type=systemd", "-v", "3"},
+			"/opt/bin",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg -v 3",
+		},
+		{
+			"../sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "../sandbox", "--job-type=systemd", "-v", "3", "-c", "systemd"},
+			"/opt/bin",
+			"/opt/bin/pupernetes run /opt/sandbox --job-type=fg -v 3 -c systemd",
+		},
+		{
+			"../sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "../sandbox", "-c", "systemd", "--job-type=systemd", "-v", "3"},
+			"/opt/bin",
+			"/opt/bin/pupernetes run /opt/sandbox -c systemd --job-type=fg -v 3",
+		},
+		{
+			"../sandbox",
+			[]string{"/opt/bin/pupernetes", "run", "../sandbox", "--clean=systemd", "--job-type=systemd", "-v", "3"},
+			"/opt/bin",
+			"/opt/bin/pupernetes run /opt/sandbox --clean=systemd --job-type=fg -v 3",
+		},
+	}
+	for _, elt := range tc {
+		t.Run("", func(t *testing.T) {
+			s, err := createExecStart(elt.givenRootPath, elt.argv, elt.wd)
+			require.NoError(t, err)
+			assert.Equal(t, elt.execStart, s)
+		})
+	}
+}

--- a/pkg/run/systemd.go
+++ b/pkg/run/systemd.go
@@ -30,7 +30,7 @@ func executeSystemdAction(unitName string, systemdAction func(string, string, ch
 			}
 		case <-timeout:
 			err := fmt.Errorf("timeout awaiting for %s unit to be done", unitName)
-			glog.Errorf("%v", err)
+			glog.Errorf("Unexpected error: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allows to run pupernetes as a systemd service from the command line.

### Motivation

Ease the usage of pupernetes during a shell script. 
Avoid to execute the command in background `&`.