### PR TITLE
Display more state of the runtime

### DIFF
--- a/docs/pupernetes.md
+++ b/docs/pupernetes.md
@@ -9,7 +9,7 @@ Use this command to clean setup and run a Kubernetes local environment
 ### Options
 
 ```
-  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,mounts,iptables")
+  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
   -h, --help                         help for pupernetes

--- a/docs/pupernetes_clean.md
+++ b/docs/pupernetes_clean.md
@@ -34,7 +34,7 @@ pupernetes clean state/ -c etcd,network,secrets
 ### Options inherited from parent commands
 
 ```
-  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,mounts,iptables")
+  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.1")

--- a/docs/pupernetes_run.md
+++ b/docs/pupernetes_run.md
@@ -51,7 +51,7 @@ pupernetes run state/ --job-type systemd
 ### Options inherited from parent commands
 
 ```
-  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,mounts,iptables")
+  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.1")

--- a/docs/pupernetes_setup.md
+++ b/docs/pupernetes_setup.md
@@ -25,7 +25,7 @@ pupernetes setup state/
 ### Options inherited from parent commands
 
 ```
-  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,mounts,iptables")
+  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.1")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,7 @@ func init() {
 	ViperConfig.SetDefault("kubectl-link", "")
 	ViperConfig.SetDefault("vault-root-token", "")
 
-	ViperConfig.SetDefault("clean", "etcd,mounts,iptables")
+	ViperConfig.SetDefault("clean", "etcd,kubelet,mounts,iptables")
 	ViperConfig.SetDefault("drain", "all")
 	ViperConfig.SetDefault("timeout", time.Hour*6)
 	ViperConfig.SetDefault("gc", time.Second*60)

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	appProbeThreshold = 10
-	kubeletCRILogs    = "/var/log/pods/"
 )
 
 type Runtime struct {
@@ -155,7 +154,7 @@ func (r *Runtime) Run() error {
 }
 
 func (r *Runtime) runDisplay() {
-	podLogs, err := ioutil.ReadDir(kubeletCRILogs)
+	podLogs, err := ioutil.ReadDir(setup.KubeletCRILogPath)
 	if err != nil {
 		glog.Errorf("Cannot read dir: %v", err)
 		return
@@ -170,7 +169,7 @@ func (r *Runtime) runDisplay() {
 			if strings.ContainsRune(pod.Name(), rune('-')) {
 				continue
 			}
-			containers, err := ioutil.ReadDir(kubeletCRILogs + pod.Name())
+			containers, err := ioutil.ReadDir(setup.KubeletCRILogPath + pod.Name())
 			if err != nil {
 				glog.Errorf("Unexpected error: %v", err)
 				continue
@@ -179,7 +178,7 @@ func (r *Runtime) runDisplay() {
 				if !container.IsDir() {
 					continue
 				}
-				containerABSPath := path.Join(kubeletCRILogs, pod.Name(), container.Name())
+				containerABSPath := path.Join(setup.KubeletCRILogPath, pod.Name(), container.Name())
 				logs, err := ioutil.ReadDir(containerABSPath)
 				if err != nil {
 					glog.Errorf("Unexpected error: %v", err)

--- a/pkg/run/state.go
+++ b/pkg/run/state.go
@@ -11,8 +11,11 @@ type State struct {
 	apiServerProbeLastError string
 	ready                   bool
 
-	kubeletProbeFail  int
-	kubeletPodRunning int
+	kubeletProbeFail      int
+	kubeletAPIPodRunning  int
+	kubeletLogsPodRunning int
+
+	kubeAPIServerRestartNb int
 }
 
 func (s *State) IsReady() bool {
@@ -50,11 +53,29 @@ func (s *State) getKubeletProbeFail() int {
 	return s.kubeletProbeFail
 }
 
-func (s *State) setKubeletPodRunning(nb int) {
+func (s *State) setKubeletAPIPodRunning(nb int) {
 	s.Lock()
-	if s.kubeletPodRunning != nb {
-		glog.Infof("Kubelet is running %d pods", nb)
-		s.kubeletPodRunning = nb
+	if s.kubeletAPIPodRunning != nb {
+		glog.Infof("Kubelet API reports %d running pods", nb)
+		s.kubeletAPIPodRunning = nb
+	}
+	s.Unlock()
+}
+
+func (s *State) setKubeletLogsPodRunning(nb int) {
+	s.Lock()
+	if s.kubeletLogsPodRunning != nb {
+		glog.Infof("Kubelet log reports %d running pods", nb)
+		s.kubeletLogsPodRunning = nb
+	}
+	s.Unlock()
+}
+
+func (s *State) setKubeAPIServerRestartNb(nb int) {
+	s.Lock()
+	if s.kubeAPIServerRestartNb != nb {
+		glog.Infof("Kube apiserver restart count: %d", nb)
+		s.kubeAPIServerRestartNb = nb
 	}
 	s.Unlock()
 }

--- a/pkg/setup/clean.go
+++ b/pkg/setup/clean.go
@@ -127,7 +127,7 @@ func (e *Environment) Clean() error {
 			e.cleanMounts()
 		}
 		toRemove = append(toRemove, e.kubeletRootDir)
-		toRemove = append(toRemove, "/var/log/pods")
+		toRemove = append(toRemove, KubeletCRILogPath)
 	}
 
 	for _, dir := range toRemove {

--- a/pkg/setup/clean.go
+++ b/pkg/setup/clean.go
@@ -127,6 +127,7 @@ func (e *Environment) Clean() error {
 			e.cleanMounts()
 		}
 		toRemove = append(toRemove, e.kubeletRootDir)
+		toRemove = append(toRemove, "/var/log/pods")
 	}
 
 	for _, dir := range toRemove {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	KubeletCRILogPath = "/var/log/pods/"
+
 	defaultBinaryDirName          = "bin"
 	defaultSourceTemplatesDirName = "source-templates"
 	defaultEtcdDataDirName        = "etcd-data"


### PR DESCRIPTION
### What does this PR do?
* remove by default the `/var/log/pods` directory
* provide more logs before being ready
* provide the number of pods in CRI log-dir `/var/log/pods`
```text
I0525 19:50:19.463448    5878 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/etcd-data
I0525 19:50:19.487854    5878 clean.go:32] Removed /var/lib/p8s-kubelet
I0525 19:50:19.579110    5878 clean.go:32] Removed /var/log/pods
I0525 19:50:19.579140    5878 clean.go:144] Cleanup successfully finished
I0525 19:50:19.659453    5878 hostname.go:59] Using hostname: "haf"
I0525 19:50:22.352439    5878 setup.go:272] Setup ready /home/jb/go/src/github.com/DataDog/pupernetes/sandbox
I0525 19:50:22.352673    5878 run.go:71] Timeout for this current run is 6h0m0s
I0525 19:50:22.352699    5878 systemd.go:40] Starting systemd unit: p8s-etcd.service ...
I0525 19:50:22.806427    5878 systemd.go:40] Starting systemd unit: p8s-kubelet.service ...
I0525 19:50:23.810346    5878 state.go:38] Kubenertes apiserver not ready yet: Get http://127.0.0.1:8080/healthz: dial tcp 127.0.0.1:8080: connect: connection refused
I0525 19:50:26.810638    5878 state.go:68] Kubelet log reports 1 running pods
I0525 19:50:26.810731    5878 run.go:189] Kubernetes apiserver not running yet
I0525 19:50:28.810619    5878 state.go:77] Kube apiserver restart count: 0
I0525 19:50:33.811313    5878 state.go:38] Kubenertes apiserver not ready yet: bad status code for http://127.0.0.1:8080/healthz: 500
I0525 19:50:36.811180    5878 kubectl.go:14] Calling kubectl apply -f /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-api ...
I0525 19:50:37.582325    5878 kubectl.go:21] Successfully applied manifests:
serviceaccount "coredns" created
clusterrole.rbac.authorization.k8s.io "system:coredns" created
clusterrolebinding.rbac.authorization.k8s.io "system:coredns" created
configmap "coredns" created
deployment.extensions "coredns" created
service "coredns" created
serviceaccount "kube-controller-manager" created
pod "kube-controller-manager" created
daemonset.extensions "kube-proxy" created
daemonset.extensions "kube-scheduler" created
clusterrolebinding.rbac.authorization.k8s.io "p8s-admin" created
I0525 19:50:37.582365    5878 notify.go:35] Compiled with CGO_ENABLED=0, unable to ack the systemd notify. PPID is 5877
I0525 19:50:37.582375    5878 run.go:151] Pupernetes is ready
I0525 19:50:37.603122    5878 state.go:59] Kubelet API reports 1 running pods
I0525 19:50:38.810645    5878 state.go:68] Kubelet log reports 2 running pods
I0525 19:50:40.812118    5878 state.go:59] Kubelet API reports 2 running pods
I0525 19:50:42.810557    5878 state.go:68] Kubelet log reports 4 running pods
I0525 19:50:44.825698    5878 state.go:59] Kubelet API reports 4 running pods
I0525 19:50:46.810344    5878 state.go:68] Kubelet log reports 5 running pods
I0525 19:50:48.824111    5878 state.go:59] Kubelet API reports 5 running pods
^CW0525 19:51:41.359352    5878 run.go:101] Signal received: "interrupt", propagating ...
I0525 19:51:41.359745    5878 stop.go:82] Draining kubelet's pods ...
I0525 19:51:41.359778    5878 stop.go:39] Graceful deleting API manifests ...
I0525 19:51:42.365259    5878 delete.go:164] Graceful deleted API manifests in 3 namespaces
I0525 19:51:43.380748    5878 stop.go:63] Kubelet run only 1 static pods
I0525 19:51:44.382464    5878 stop.go:126] Kubelet doesn't run any pod, waiting 1m0s for the kubelet's gc or SIGINT
I0525 19:52:44.382668    5878 stop.go:133] GC period reached
I0525 19:52:44.382921    5878 systemd.go:45] Stopping systemd unit: p8s-kubelet.service ...
I0525 19:52:44.402141    5878 systemd.go:45] Stopping systemd unit: p8s-etcd.service ...
```
### Motivation

Give more visibility of what's happening.

