### PR TITLE
Display the adapted config in the logs

### DIFF
--- a/pkg/setup/kubeclient.go
+++ b/pkg/setup/kubeclient.go
@@ -191,7 +191,7 @@ func (e *Environment) setupKubeletClient() error {
 
 func (e *Environment) setupAPIServerClient() error {
 	var err error
-	glog.V(4).Infof("Building restConfig from %s", e.GetKubeconfigAuthPath())
+	glog.V(4).Infof("Building restConfig from %s", e.GetKubeconfigInsecurePath())
 	e.restConfig, err = clientcmd.BuildConfigFromFlags("", e.GetKubeconfigInsecurePath())
 	if err != nil {
 		glog.Errorf("Cannot build restConfig: %v", err)


### PR DESCRIPTION
### What does this PR do?

The logging message isn't the used configuration file.

