### PR TITLE
Introduce the daemon and the reset commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,21 +66,21 @@ jobs:
 
       - run:
           name: setup
-          command: sudo ./pupernetes setup sandbox/
+          command: sudo ./pupernetes daemon setup sandbox/
 
       - run:
           name: already-setup
           # As it's already setup, pupernetes should be very fast
-          command: sudo timeout 10 ./pupernetes setup sandbox/
+          command: sudo timeout 10 ./pupernetes daemon setup sandbox/
 
       - run:
           name: clean-setup
           # As we kept the binaries, pupernetes should be very fast
-          command: sudo timeout 10 ./pupernetes setup sandbox/ -c etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd
+          command: sudo timeout 10 ./pupernetes daemon setup sandbox/ -c etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd
 
       - run:
           name: clean
-          command: sudo ./pupernetes clean sandbox/ -c all
+          command: sudo ./pupernetes daemon clean sandbox/ -c all
 
 workflows:
   version: 2

--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -182,13 +182,13 @@ func NewCommand() (*cobra.Command, *int) {
 		Short:      "Reset the Kubernetes resources in the given namespace",
 		Args:       cobra.MinimumNArgs(1), // namespace
 		Example: fmt.Sprintf(`
-# Reset the namespace default:
+# Reset the default namespace:
 %s reset default
 
-# Reset the namespace kube-system and redeploy the initial setup:
+# Reset the kube-system namespace and redeploy the initial setup:
 %s reset kube-system --apply
 
-# Reset the namespaces default and kube-system then redeploy the initial setup:
+# Reset the default and kube-system namespaces then redeploy the initial setup:
 %s reset default kube-system --apply
 
 # Reset all namespaces and redeploy the initial setup:
@@ -210,7 +210,7 @@ func NewCommand() (*cobra.Command, *int) {
 			if !config.ViperConfig.GetBool("apply") {
 				return
 			}
-			err := api.ReApply(config.ViperConfig.GetString("api-address"))
+			err := api.Apply(config.ViperConfig.GetString("api-address"))
 			if err != nil {
 				exitCode = 2
 				return
@@ -269,7 +269,7 @@ func NewCommand() (*cobra.Command, *int) {
 	runCommand.PersistentFlags().Duration("gc", config.ViperConfig.GetDuration("gc"), fmt.Sprintf("grace period for the kubelet GC trigger when draining %s, no-op if not draining", runCommand.Name()))
 	config.ViperConfig.BindPFlag("gc", runCommand.PersistentFlags().Lookup("gc"))
 
-	runCommand.PersistentFlags().String("bind-address", config.ViperConfig.GetString("bind-address"), "bind address for the API ip:port")
+	runCommand.PersistentFlags().String("bind-address", config.ViperConfig.GetString("bind-address"), fmt.Sprintf("Bind address for %s API ip:port", programName))
 	config.ViperConfig.BindPFlag("bind-address", runCommand.PersistentFlags().Lookup("bind-address"))
 
 	runCommand.PersistentFlags().String("systemd-job-name", config.ViperConfig.GetString("systemd-job-name"), "unit name used when running as systemd service")
@@ -280,7 +280,7 @@ func NewCommand() (*cobra.Command, *int) {
 
 	// Reset
 	rootCommand.AddCommand(resetCommand)
-	resetCommand.PersistentFlags().String("api-address", config.ViperConfig.GetString("api-address"), "Address for the API ip:port")
+	resetCommand.PersistentFlags().String("api-address", config.ViperConfig.GetString("api-address"), fmt.Sprintf("Address for the %s API ip:port", programName))
 	config.ViperConfig.BindPFlag("api-address", resetCommand.PersistentFlags().Lookup("api-address"))
 
 	resetCommand.PersistentFlags().BoolP("apply", "a", config.ViperConfig.GetBool("apply"), "Apply manifests-api after reset, useful when resetting kube-system namespace")

--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/pupernetes/pkg/api"
 	"github.com/DataDog/pupernetes/pkg/config"
 	"github.com/DataDog/pupernetes/pkg/job"
 	"github.com/DataDog/pupernetes/pkg/options"
@@ -28,35 +29,38 @@ func NewCommand() (*cobra.Command, *int) {
 
 	rootCommand := &cobra.Command{
 		Use:   fmt.Sprintf("%s command line", programName),
-		Short: "Use this command to clean setup and run a Kubernetes local environment",
+		Short: "Use this command to manage a Kubernetes local environment",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			flag.Lookup("alsologtostderr").Value.Set("true")
 			flag.Lookup("v").Value.Set(strconv.Itoa(verbose))
 		},
 	}
 
+	daemonCommand := &cobra.Command{
+		Use:   "daemon command line",
+		Short: "Use this command to clean setup and run a Kubernetes local environment",
+	}
+	daemonName := fmt.Sprintf("%s %s", programName, daemonCommand.Name())
+
 	setupCommand := &cobra.Command{
 		SuggestFor: []string{"prepare"},
 		Use:        "setup [directory]",
 		Short:      "Setup the environment",
 		Args:       cobra.ExactArgs(1), // basePathDirectory
-		Example:    fmt.Sprintf("%s setup state/", programName),
+		Example:    fmt.Sprintf("%s setup state/", daemonName),
 		Run: func(cmd *cobra.Command, args []string) {
 			env, err := setup.NewConfigSetup(args[0])
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = env.Clean()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = env.Setup()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
@@ -89,12 +93,16 @@ func NewCommand() (*cobra.Command, *int) {
 # Get status with "systemctl status %s --no-pager" 
 %s run state/ --%s %s
 `,
-			programName,
-			programName,
-			programName,
-			programName,
-			programName,
-			config.ViperConfig.GetString("systemd-job-name"), config.ViperConfig.GetString("systemd-job-name"), programName, config.JobTypeKey, config.JobSystemd,
+			daemonName,
+			daemonName,
+			daemonName,
+			daemonName,
+			daemonName,
+			config.ViperConfig.GetString("systemd-job-name"),
+			config.ViperConfig.GetString("systemd-job-name"),
+			daemonName,
+			config.JobTypeKey,
+			config.JobSystemd,
 		),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Manage self start in systemd
@@ -103,7 +111,6 @@ func NewCommand() (*cobra.Command, *int) {
 				glog.V(2).Infof("Self starting as systemd unit %s.service ...", config.ViperConfig.GetString("systemd-job-name"))
 				err := job.RunSystemdJob(args[0])
 				if err != nil {
-					glog.Errorf("Command returns error: %v", err)
 					exitCode = 1
 				}
 				return
@@ -114,25 +121,21 @@ func NewCommand() (*cobra.Command, *int) {
 
 			env, err := setup.NewConfigSetup(args[0])
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = env.Clean()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = env.Setup()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = run.NewRunner(env).Run()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 2
 				return
 			}
@@ -153,18 +156,63 @@ func NewCommand() (*cobra.Command, *int) {
 
 # Clean the etcd data-dir, the network configuration and the secrets:
 %s clean state/ -c etcd,network,secrets
-`, programName, programName, programName),
+`,
+			daemonName,
+			daemonName,
+			daemonName,
+		),
 		Run: func(cmd *cobra.Command, args []string) {
 			env, err := setup.NewConfigSetup(args[0])
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
 				return
 			}
 			err = env.Clean()
 			if err != nil {
-				glog.Errorf("Command returns error: %v", err)
 				exitCode = 1
+				return
+			}
+		},
+	}
+
+	resetCommand := &cobra.Command{
+		SuggestFor: []string{"rest", "rst", "rset", "erase", "restart"},
+		Use:        "reset [namespaces ...]",
+		Aliases:    []string{"r"},
+		Short:      "Reset the Kubernetes resources in the given namespace",
+		Args:       cobra.MinimumNArgs(1), // namespace
+		Example: fmt.Sprintf(`
+# Reset the namespace default:
+%s reset default
+
+# Reset the namespace kube-system and redeploy the initial setup:
+%s reset kube-system --apply
+
+# Reset the namespaces default and kube-system then redeploy the initial setup:
+%s reset default kube-system --apply
+
+# Reset all namespaces and redeploy the initial setup:
+%s reset default $(kubectl get ns -o name) --apply
+`,
+			programName,
+			programName,
+			programName,
+			programName,
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			for i := 0; i < len(args); i++ {
+				err := api.ResetNamespace(config.ViperConfig.GetString("api-address"), args[i])
+				if err != nil {
+					exitCode = 2
+					return
+				}
+			}
+			if !config.ViperConfig.GetBool("apply") {
+				return
+			}
+			err := api.ReApply(config.ViperConfig.GetString("api-address"))
+			if err != nil {
+				exitCode = 2
 				return
 			}
 		},
@@ -173,41 +221,44 @@ func NewCommand() (*cobra.Command, *int) {
 	// root
 	rootCommand.PersistentFlags().IntVarP(&verbose, "verbose", "v", 2, "verbose level")
 
-	rootCommand.PersistentFlags().String("hyperkube-version", config.ViperConfig.GetString("hyperkube-version"), "hyperkube version")
-	config.ViperConfig.BindPFlag("hyperkube-version", rootCommand.PersistentFlags().Lookup("hyperkube-version"))
+	// daemon command
+	rootCommand.AddCommand(daemonCommand)
 
-	rootCommand.PersistentFlags().String("vault-version", config.ViperConfig.GetString("vault-version"), "vault version")
-	config.ViperConfig.BindPFlag("vault-version", rootCommand.PersistentFlags().Lookup("vault-version"))
+	daemonCommand.PersistentFlags().String("hyperkube-version", config.ViperConfig.GetString("hyperkube-version"), "hyperkube version")
+	config.ViperConfig.BindPFlag("hyperkube-version", daemonCommand.PersistentFlags().Lookup("hyperkube-version"))
 
-	rootCommand.PersistentFlags().String("etcd-version", config.ViperConfig.GetString("etcd-version"), "etcd version")
-	config.ViperConfig.BindPFlag("etcd-version", rootCommand.PersistentFlags().Lookup("etcd-version"))
+	daemonCommand.PersistentFlags().String("vault-version", config.ViperConfig.GetString("vault-version"), "vault version")
+	config.ViperConfig.BindPFlag("vault-version", daemonCommand.PersistentFlags().Lookup("vault-version"))
 
-	rootCommand.PersistentFlags().String("cni-version", config.ViperConfig.GetString("cni-version"), "container network interface (cni) version")
-	config.ViperConfig.BindPFlag("cni-version", rootCommand.PersistentFlags().Lookup("cni-version"))
+	daemonCommand.PersistentFlags().String("etcd-version", config.ViperConfig.GetString("etcd-version"), "etcd version")
+	config.ViperConfig.BindPFlag("etcd-version", daemonCommand.PersistentFlags().Lookup("etcd-version"))
 
-	rootCommand.PersistentFlags().String("kubelet-root-dir", config.ViperConfig.GetString("kubelet-root-dir"), "directory path for managing kubelet files")
-	config.ViperConfig.BindPFlag("kubelet-root-dir", rootCommand.PersistentFlags().Lookup("kubelet-root-dir"))
+	daemonCommand.PersistentFlags().String("cni-version", config.ViperConfig.GetString("cni-version"), "container network interface (cni) version")
+	config.ViperConfig.BindPFlag("cni-version", daemonCommand.PersistentFlags().Lookup("cni-version"))
 
-	rootCommand.PersistentFlags().String("systemd-unit-prefix", config.ViperConfig.GetString("systemd-unit-prefix"), "prefix for systemd unit name")
-	config.ViperConfig.BindPFlag("systemd-unit-prefix", rootCommand.PersistentFlags().Lookup("systemd-unit-prefix"))
+	daemonCommand.PersistentFlags().String("kubelet-root-dir", config.ViperConfig.GetString("kubelet-root-dir"), "directory path for managing kubelet files")
+	config.ViperConfig.BindPFlag("kubelet-root-dir", daemonCommand.PersistentFlags().Lookup("kubelet-root-dir"))
 
-	rootCommand.PersistentFlags().Int("kubelet-cadvisor-port", config.ViperConfig.GetInt("kubelet-cadvisor-port"), "enable kubelet cAdvisor on port")
-	config.ViperConfig.BindPFlag("kubelet-cadvisor-port", rootCommand.PersistentFlags().Lookup("kubelet-cadvisor-port"))
+	daemonCommand.PersistentFlags().String("systemd-unit-prefix", config.ViperConfig.GetString("systemd-unit-prefix"), "prefix for systemd unit name")
+	config.ViperConfig.BindPFlag("systemd-unit-prefix", daemonCommand.PersistentFlags().Lookup("systemd-unit-prefix"))
 
-	rootCommand.PersistentFlags().String("kubectl-link", config.ViperConfig.GetString("kubectl-link"), "Path to create a kubectl link")
-	config.ViperConfig.BindPFlag("kubectl-link", rootCommand.PersistentFlags().Lookup("kubectl-link"))
+	daemonCommand.PersistentFlags().Int("kubelet-cadvisor-port", config.ViperConfig.GetInt("kubelet-cadvisor-port"), "enable kubelet cAdvisor on port")
+	config.ViperConfig.BindPFlag("kubelet-cadvisor-port", daemonCommand.PersistentFlags().Lookup("kubelet-cadvisor-port"))
 
-	rootCommand.PersistentFlags().StringP("clean", "c", config.ViperConfig.GetString("clean"), fmt.Sprintf("clean options before %s: %s", setupCommand.Name(), options.GetOptionNames(options.Clean{})))
-	config.ViperConfig.BindPFlag("clean", rootCommand.PersistentFlags().Lookup("clean"))
+	daemonCommand.PersistentFlags().String("kubectl-link", config.ViperConfig.GetString("kubectl-link"), "Path to create a kubectl link")
+	config.ViperConfig.BindPFlag("kubectl-link", daemonCommand.PersistentFlags().Lookup("kubectl-link"))
+
+	daemonCommand.PersistentFlags().StringP("clean", "c", config.ViperConfig.GetString("clean"), fmt.Sprintf("clean options before %s: %s", setupCommand.Name(), options.GetOptionNames(options.Clean{})))
+	config.ViperConfig.BindPFlag("clean", daemonCommand.PersistentFlags().Lookup("clean"))
 
 	// clean
-	rootCommand.AddCommand(cleanCommand)
+	daemonCommand.AddCommand(cleanCommand)
 
 	// setup
-	rootCommand.AddCommand(setupCommand)
+	daemonCommand.AddCommand(setupCommand)
 
 	// run
-	rootCommand.AddCommand(runCommand)
+	daemonCommand.AddCommand(runCommand)
 
 	runCommand.PersistentFlags().StringP("drain", "d", config.ViperConfig.GetString("drain"), fmt.Sprintf("drain options after %s: %s", runCommand.Name(), options.GetOptionNames(options.Drain{})))
 	config.ViperConfig.BindPFlag("drain", runCommand.PersistentFlags().Lookup("drain"))
@@ -226,6 +277,14 @@ func NewCommand() (*cobra.Command, *int) {
 
 	runCommand.PersistentFlags().String(config.JobTypeKey, config.ViperConfig.GetString(config.JobTypeKey), fmt.Sprintf("type of job: %s or %s", config.JobForeground, config.JobSystemd))
 	config.ViperConfig.BindPFlag(config.JobTypeKey, runCommand.PersistentFlags().Lookup(config.JobTypeKey))
+
+	// Reset
+	rootCommand.AddCommand(resetCommand)
+	resetCommand.PersistentFlags().String("api-address", config.ViperConfig.GetString("api-address"), "Address for the API ip:port")
+	config.ViperConfig.BindPFlag("api-address", resetCommand.PersistentFlags().Lookup("api-address"))
+
+	resetCommand.PersistentFlags().BoolP("apply", "a", config.ViperConfig.GetBool("apply"), "Apply manifests-api after reset, useful when resetting kube-system namespace")
+	config.ViperConfig.BindPFlag("apply", resetCommand.PersistentFlags().Lookup("apply"))
 
 	return rootCommand, &exitCode
 }

--- a/docs/pupernetes.md
+++ b/docs/pupernetes.md
@@ -1,30 +1,20 @@
 ## pupernetes
 
-Use this command to clean setup and run a Kubernetes local environment
+Use this command to manage a Kubernetes local environment
 
 ### Synopsis
 
-Use this command to clean setup and run a Kubernetes local environment
+Use this command to manage a Kubernetes local environment
 
 ### Options
 
 ```
-  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
-      --cni-version string           container network interface (cni) version (default "0.7.0")
-      --etcd-version string          etcd version (default "3.1.11")
-  -h, --help                         help for pupernetes
-      --hyperkube-version string     hyperkube version (default "1.10.1")
-      --kubectl-link string          Path to create a kubectl link
-      --kubelet-cadvisor-port int    enable kubelet cAdvisor on port
-      --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
-      --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")
-      --vault-version string         vault version (default "0.9.5")
-  -v, --verbose int                  verbose level (default 2)
+  -h, --help          help for pupernetes
+  -v, --verbose int   verbose level (default 2)
 ```
 
 ### SEE ALSO
 
-* [pupernetes clean](pupernetes_clean.md)	 - Clean the environment created by setup and altered by a run
-* [pupernetes run](pupernetes_run.md)	 - setup and run the environment
-* [pupernetes setup](pupernetes_setup.md)	 - Setup the environment
+* [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
+* [pupernetes reset](pupernetes_reset.md)	 - Reset the Kubernetes resources in the given namespace
 

--- a/docs/pupernetes_daemon.md
+++ b/docs/pupernetes_daemon.md
@@ -1,43 +1,36 @@
-## pupernetes setup
+## pupernetes daemon
 
-Setup the environment
+Use this command to clean setup and run a Kubernetes local environment
 
 ### Synopsis
 
-Setup the environment
-
-```
-pupernetes setup [directory] [flags]
-```
-
-### Examples
-
-```
-pupernetes setup state/
-```
+Use this command to clean setup and run a Kubernetes local environment
 
 ### Options
-
-```
-  -h, --help   help for setup
-```
-
-### Options inherited from parent commands
 
 ```
   -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
+  -h, --help                         help for daemon
       --hyperkube-version string     hyperkube version (default "1.10.1")
       --kubectl-link string          Path to create a kubectl link
       --kubelet-cadvisor-port int    enable kubelet cAdvisor on port
       --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
       --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")
       --vault-version string         vault version (default "0.9.5")
-  -v, --verbose int                  verbose level (default 2)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose int   verbose level (default 2)
 ```
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
+* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes local environment
+* [pupernetes daemon clean](pupernetes_daemon_clean.md)	 - Clean the environment created by setup and altered by a run
+* [pupernetes daemon run](pupernetes_daemon_run.md)	 - setup and run the environment
+* [pupernetes daemon setup](pupernetes_daemon_setup.md)	 - Setup the environment
 

--- a/docs/pupernetes_daemon_clean.md
+++ b/docs/pupernetes_daemon_clean.md
@@ -1,4 +1,4 @@
-## pupernetes clean
+## pupernetes daemon clean
 
 Clean the environment created by setup and altered by a run
 
@@ -7,7 +7,7 @@ Clean the environment created by setup and altered by a run
 Clean the environment created by setup and altered by a run
 
 ```
-pupernetes clean [directory] [flags]
+pupernetes daemon clean [directory] [flags]
 ```
 
 ### Examples
@@ -15,13 +15,13 @@ pupernetes clean [directory] [flags]
 ```
 
 # Clean the environment default:
-pupernetes clean state/
+pupernetes daemon clean state/
 
 # Clean everything:
-pupernetes clean state/ -c all
+pupernetes daemon clean state/ -c all
 
 # Clean the etcd data-dir, the network configuration and the secrets:
-pupernetes clean state/ -c etcd,network,secrets
+pupernetes daemon clean state/ -c etcd,network,secrets
 
 ```
 
@@ -48,5 +48,5 @@ pupernetes clean state/ -c etcd,network,secrets
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
+* [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
 

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -1,4 +1,4 @@
-## pupernetes run
+## pupernetes daemon run
 
 setup and run the environment
 
@@ -7,7 +7,7 @@ setup and run the environment
 setup and run the environment
 
 ```
-pupernetes run [directory] [flags]
+pupernetes daemon run [directory] [flags]
 ```
 
 ### Examples
@@ -15,24 +15,24 @@ pupernetes run [directory] [flags]
 ```
 
 # Setup and run the environment with the default options: 
-pupernetes run state/
+pupernetes daemon run state/
 
 # Clean all the environment, setup and run the environment:
-pupernetes run state/ -c all
+pupernetes daemon run state/ -c all
 
 # Clean everything but the binaries, setup and run the environment:
-pupernetes run state/ -c etcd,kubectl,kubelet,manifests,network,secrets,systemd,mounts
+pupernetes daemon run state/ -c etcd,kubectl,kubelet,manifests,network,secrets,systemd,mounts
 
 # Setup and run the environment with a 5 minutes timeout: 
-pupernetes run state/ --timeout 5m
+pupernetes daemon run state/ --timeout 5m
 
 # Setup and run the environment, then garantee a kubelet garbage collection during the drain phase: 
-pupernetes run state/ --gc 1m
+pupernetes daemon run state/ --gc 1m
 
 # Setup and run the environment as a systemd service:
 # Get logs with "journalctl -o cat -efu pupernetes" 
 # Get status with "systemctl status pupernetes --no-pager" 
-pupernetes run state/ --job-type systemd
+pupernetes daemon run state/ --job-type systemd
 
 ```
 
@@ -65,5 +65,5 @@ pupernetes run state/ --job-type systemd
 
 ### SEE ALSO
 
-* [pupernetes](pupernetes.md)	 - Use this command to clean setup and run a Kubernetes local environment
+* [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
 

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -39,7 +39,7 @@ pupernetes daemon run state/ --job-type systemd
 ### Options
 
 ```
-      --bind-address string       bind address for the API ip:port (default "127.0.0.1:8989")
+      --bind-address string       Bind address for pupernetes API ip:port (default "127.0.0.1:8989")
   -d, --drain string              drain options after run: iptables,kubeletgc,pods,all,none (default "all")
       --gc duration               grace period for the kubelet GC trigger when draining run, no-op if not draining (default 1m0s)
   -h, --help                      help for run

--- a/docs/pupernetes_daemon_setup.md
+++ b/docs/pupernetes_daemon_setup.md
@@ -1,0 +1,43 @@
+## pupernetes daemon setup
+
+Setup the environment
+
+### Synopsis
+
+Setup the environment
+
+```
+pupernetes daemon setup [directory] [flags]
+```
+
+### Examples
+
+```
+pupernetes daemon setup state/
+```
+
+### Options
+
+```
+  -h, --help   help for setup
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --clean string                 clean options before setup: binaries,etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,mounts,iptables")
+      --cni-version string           container network interface (cni) version (default "0.7.0")
+      --etcd-version string          etcd version (default "3.1.11")
+      --hyperkube-version string     hyperkube version (default "1.10.1")
+      --kubectl-link string          Path to create a kubectl link
+      --kubelet-cadvisor-port int    enable kubelet cAdvisor on port
+      --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
+      --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")
+      --vault-version string         vault version (default "0.9.5")
+  -v, --verbose int                  verbose level (default 2)
+```
+
+### SEE ALSO
+
+* [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
+

--- a/docs/pupernetes_reset.md
+++ b/docs/pupernetes_reset.md
@@ -1,0 +1,48 @@
+## pupernetes reset
+
+Reset the Kubernetes resources in the given namespace
+
+### Synopsis
+
+Reset the Kubernetes resources in the given namespace
+
+```
+pupernetes reset [namespaces ...] [flags]
+```
+
+### Examples
+
+```
+
+# Reset the namespace default:
+pupernetes reset default
+
+# Reset the namespace kube-system and redeploy the initial setup:
+pupernetes reset kube-system --apply
+
+# Reset the namespaces default and kube-system then redeploy the initial setup:
+pupernetes reset default kube-system --apply
+
+# Reset all namespaces and redeploy the initial setup:
+pupernetes reset default $(kubectl get ns -o name) --apply
+
+```
+
+### Options
+
+```
+      --api-address string   Address for the API ip:port (default "127.0.0.1:8989")
+  -a, --apply                Apply manifests-api after reset, useful when resetting kube-system namespace
+  -h, --help                 help for reset
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose int   verbose level (default 2)
+```
+
+### SEE ALSO
+
+* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes local environment
+

--- a/docs/pupernetes_reset.md
+++ b/docs/pupernetes_reset.md
@@ -14,13 +14,13 @@ pupernetes reset [namespaces ...] [flags]
 
 ```
 
-# Reset the namespace default:
+# Reset the default namespace:
 pupernetes reset default
 
-# Reset the namespace kube-system and redeploy the initial setup:
+# Reset the kube-system namespace and redeploy the initial setup:
 pupernetes reset kube-system --apply
 
-# Reset the namespaces default and kube-system then redeploy the initial setup:
+# Reset the default and kube-system namespaces then redeploy the initial setup:
 pupernetes reset default kube-system --apply
 
 # Reset all namespaces and redeploy the initial setup:
@@ -31,7 +31,7 @@ pupernetes reset default $(kubectl get ns -o name) --apply
 ### Options
 
 ```
-      --api-address string   Address for the API ip:port (default "127.0.0.1:8989")
+      --api-address string   Address for the pupernetes API ip:port (default "127.0.0.1:8989")
   -a, --apply                Apply manifests-api after reset, useful when resetting kube-system namespace
   -h, --help                 help for reset
 ```

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	stopRoute  = "/stop"
+	applyRoute = "/apply"
+	resetRoute = "/reset"
+)
+
 // HandlerAPI handles the API calls
 type HandlerAPI struct {
 	sigChan        chan os.Signal
@@ -75,11 +81,14 @@ func NewAPI(sigChan chan os.Signal, resetNamespaceFn func(namespaces *corev1.Nam
 		apply:          apply,
 	}
 	r := mux.NewRouter()
+
+	// POSTs
 	r.Methods("POST").Path("/stop").HandlerFunc(h.stopHandler)
-	r.Methods("POST").Path("/apply").HandlerFunc(h.applyHandler)
-	r.Methods("POST").Path("/reset/{namespace}").HandlerFunc(h.resetHandler)
+	r.Methods("POST").Path(applyRoute).HandlerFunc(h.applyHandler)
+	r.Methods("POST").Path(resetRoute + "/{namespace}").HandlerFunc(h.resetHandler)
+
+	// GETs
 	r.Methods("GET").Path("/ready").HandlerFunc(h.isReadyHandler)
-	r.Methods("GET").Path("/re-apply").HandlerFunc(h.isReadyHandler)
 
 	srv := &http.Server{
 		Handler:      r,

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	namespacePrefix = "namespace/"
+)
+
+func ResetNamespace(apiAddress, namespace string) error {
+	if strings.HasPrefix(namespace, namespacePrefix) {
+		glog.V(4).Infof("Stripping namespace %q", namespace)
+		namespace = namespace[len(namespacePrefix):]
+		glog.V(4).Infof("Namespace renamed as: %q", namespace)
+	}
+	if namespace == "" {
+		err := fmt.Errorf("empty namespace")
+		glog.Infof("Cannot continue: %v", err)
+		return err
+	}
+	glog.Infof("Resetting namespace %q ...", namespace)
+	c := &http.Client{}
+	c.Timeout = time.Second * 5
+
+	u, err := url.Parse(fmt.Sprintf("http://%s/reset/%s", apiAddress, namespace))
+	if err != nil {
+		glog.Errorf("Error during urlParse: %v", err)
+		return err
+	}
+	glog.V(3).Infof("Using url: %s", u.String())
+	resp, err := c.Post(u.String(), "application/json", nil)
+	if err != nil {
+		glog.Errorf("Unexpected error during reset namespace %s: %v", namespace, err)
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		err := fmt.Errorf("non OK status code when deleting ns %s: %d", namespace, resp.StatusCode)
+		glog.Errorf("Cannot delete namespace: %v", err)
+		return err
+	}
+	glog.Infof("Namespace %q successfully reset", namespace)
+	return nil
+}
+
+func ReApply(apiAddress string) error {
+	glog.Infof("Re-applying ...")
+	c := &http.Client{}
+	c.Timeout = time.Second * 5
+
+	u, err := url.Parse(fmt.Sprintf("http://%s/re-apply", apiAddress))
+	if err != nil {
+		glog.Errorf("Error during urlParse: %v", err)
+		return err
+	}
+	glog.V(3).Infof("Using url: %s", u.String())
+	resp, err := c.Post(u.String(), "application/json", nil)
+	if err != nil {
+		glog.Errorf("Unexpected error during re-applying: %v", err)
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		err := fmt.Errorf("non OK status code when re-applying: %d", resp.StatusCode)
+		glog.Errorf("Cannot re-apply: %v", err)
+		return err
+	}
+	glog.Infof("Re-apply successful")
+	return nil
+}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -25,35 +25,20 @@ func ResetNamespace(apiAddress, namespace string) error {
 		return err
 	}
 	glog.Infof("Resetting namespace %q ...", namespace)
-	c := &http.Client{}
-	c.Timeout = time.Second * 5
-
-	u, err := url.Parse(fmt.Sprintf("http://%s/reset/%s", apiAddress, namespace))
-	if err != nil {
-		glog.Errorf("Error during urlParse: %v", err)
-		return err
-	}
-	glog.V(3).Infof("Using url: %s", u.String())
-	resp, err := c.Post(u.String(), "application/json", nil)
-	if err != nil {
-		glog.Errorf("Unexpected error during reset namespace %s: %v", namespace, err)
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("non OK status code when deleting ns %s: %d", namespace, resp.StatusCode)
-		glog.Errorf("Cannot delete namespace: %v", err)
-		return err
-	}
-	glog.Infof("Namespace %q successfully reset", namespace)
-	return nil
+	return doPOST(apiAddress, fmt.Sprintf("%s/%s", resetRoute, namespace))
 }
 
-func ReApply(apiAddress string) error {
-	glog.Infof("Re-applying ...")
+func Apply(apiAddress string) error {
+	glog.Infof("Applying ...")
+	return doPOST(apiAddress, applyRoute)
+}
+
+func doPOST(apiAddress, apiRoute string) error {
+	glog.Infof("Calling POST %s ...", apiRoute)
 	c := &http.Client{}
 	c.Timeout = time.Second * 5
 
-	u, err := url.Parse(fmt.Sprintf("http://%s/re-apply", apiAddress))
+	u, err := url.Parse(fmt.Sprintf("http://%s%s", apiAddress, apiRoute))
 	if err != nil {
 		glog.Errorf("Error during urlParse: %v", err)
 		return err
@@ -61,14 +46,14 @@ func ReApply(apiAddress string) error {
 	glog.V(3).Infof("Using url: %s", u.String())
 	resp, err := c.Post(u.String(), "application/json", nil)
 	if err != nil {
-		glog.Errorf("Unexpected error during re-applying: %v", err)
+		glog.Errorf("Unexpected error during POST %s: %v", u.String(), err)
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("non OK status code when re-applying: %d", resp.StatusCode)
-		glog.Errorf("Cannot re-apply: %v", err)
+		err := fmt.Errorf("non OK status code when POST %s: %d", u.String(), resp.StatusCode)
+		glog.Errorf("Cannot POST: %v", err)
 		return err
 	}
-	glog.Infof("Re-apply successful")
+	glog.Infof("POST on %s successfully executed: %d", u.String(), resp.StatusCode)
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ func init() {
 
 	ViperConfig.SetDefault("kubernetes-cluster-ip-range", "192.168.254.0/24")
 	ViperConfig.SetDefault("bind-address", "127.0.0.1:8989")
+	ViperConfig.SetDefault("api-address", "127.0.0.1:8989")
 	ViperConfig.SetDefault("kubelet-root-dir", "/var/lib/p8s-kubelet")
 	ViperConfig.SetDefault("systemd-unit-prefix", "p8s-")
 
@@ -44,4 +45,6 @@ func init() {
 	ViperConfig.SetDefault("systemd-job-name", "pupernetes")
 
 	ViperConfig.SetDefault("kubelet-cadvisor-port", 0)
+
+	ViperConfig.SetDefault("apply", false)
 }

--- a/pkg/run/delete.go
+++ b/pkg/run/delete.go
@@ -20,14 +20,14 @@ func (r *Runtime) deleteDeployments(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().AppsV1beta1().Deployments(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Deployments -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Deployments in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Deployments in ns %q ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().AppsV1beta1().Deployments(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil {
-				glog.Errorf("Cannot delete Deployments %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Deployments %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -43,14 +43,14 @@ func (r *Runtime) deleteDaemonset(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().AppsV1().DaemonSets(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get DaemonSets -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get DaemonSets in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d DaemonSets in ns %q ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().AppsV1().DaemonSets(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil {
-				glog.Errorf("Cannot delete DaemonSets %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete DaemonSets %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -66,14 +66,14 @@ func (r *Runtime) deleteReplicationController(namespaces *corev1.NamespaceList) 
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().ReplicationControllers(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get ReplicationControllers -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get ReplicationControllers in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d ReplicationControllers in ns %q ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().AppsV1().DaemonSets(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil {
-				glog.Errorf("Cannot delete ReplicationControllers %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete ReplicationControllers %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -89,14 +89,14 @@ func (r *Runtime) deleteReplicaSets(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().AppsV1().ReplicaSets(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get ReplicaSets -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get ReplicaSets in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d ReplicaSets in ns %q ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().AppsV1().ReplicaSets(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete ReplicaSets %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete ReplicaSets %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -112,14 +112,14 @@ func (r *Runtime) deleteJobs(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().BatchV1().Jobs(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Jobs -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Jobs in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Jobs in ns %q ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().BatchV1().Jobs(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete Jobs %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Jobs %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -135,14 +135,14 @@ func (r *Runtime) deletePods(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().Pods(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Pods -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Pods in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Pods in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().Pods(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete Pods %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Pods %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -158,14 +158,14 @@ func (r *Runtime) deleteServices(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().Services(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Services -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Services in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Services in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().Services(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete Services %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Services %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -181,14 +181,14 @@ func (r *Runtime) deleteEndpoints(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().Endpoints(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Endpoints -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Endpoints in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Endpoints in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().Endpoints(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete Endpoints %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Endpoints %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -204,14 +204,14 @@ func (r *Runtime) deleteConfigMaps(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().ConfigMaps(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get ConfigMaps -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get ConfigMaps in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d ConfigMaps in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().ConfigMaps(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete ConfigMaps %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete ConfigMaps %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -227,14 +227,14 @@ func (r *Runtime) deleteSecrets(namespaces *corev1.NamespaceList) error {
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().Secrets(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get Secrets -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get Secrets in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d Secrets in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().Secrets(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete Secrets %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete Secrets %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}
@@ -250,14 +250,14 @@ func (r *Runtime) deleteServiceAccounts(namespaces *corev1.NamespaceList) error 
 	for _, ns := range namespaces.Items {
 		toDelete, err := r.env.GetKubernetesClient().CoreV1().ServiceAccounts(ns.Name).List(v1.ListOptions{})
 		if err != nil {
-			glog.Errorf("Cannot get ServiceAccounts -n %s: %v", ns.Name, err)
+			glog.Errorf("Cannot get ServiceAccounts in ns %q: %v", ns.Name, err)
 			return err
 		}
 		glog.V(4).Infof("Deleting %d ServiceAccounts in ns %s ...", len(toDelete.Items), ns.Name)
 		for _, elt := range toDelete.Items {
 			err = r.env.GetKubernetesClient().CoreV1().ServiceAccounts(elt.Namespace).Delete(elt.Name, r.kubeDeleteOption)
 			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("Cannot delete ServiceAccounts %s -n %q: %v", elt.Name, elt.Namespace, err)
+				glog.Errorf("Cannot delete ServiceAccounts %s in ns %q: %v", elt.Name, elt.Namespace, err)
 				errs = append(errs, err.Error())
 			}
 		}

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -41,17 +41,15 @@ type Runtime struct {
 	waitKubeletGC    time.Duration
 	kubeDeleteOption *v1.DeleteOptions
 
-	ReApplyChan chan struct{}
+	ApplyChan chan struct{}
 }
 
 func NewRunner(env *setup.Environment) *Runtime {
 	var zero int64 = 0
-	sigChan := make(chan os.Signal, 2)
-	reApplyChan := make(chan struct{})
 
 	run := &Runtime{
 		env:     env,
-		SigChan: sigChan,
+		SigChan: make(chan os.Signal, 2),
 		httpClient: &http.Client{
 			Timeout: time.Millisecond * 500,
 		},
@@ -63,19 +61,19 @@ func NewRunner(env *setup.Environment) *Runtime {
 		kubeDeleteOption: &v1.DeleteOptions{
 			GracePeriodSeconds: &zero,
 		},
-		ReApplyChan: reApplyChan,
+		ApplyChan: make(chan struct{}),
 	}
 	signal.Notify(run.SigChan, syscall.SIGTERM, syscall.SIGINT)
-	run.api = api.NewAPI(run.SigChan, run.DeleteAPIManifests, run.state.IsReady, reApplyChan)
+	run.api = api.NewAPI(run.SigChan, run.DeleteAPIManifests, run.state.IsReady, run.ApplyChan)
 	return run
 }
 
 func (r *Runtime) Run() error {
-	defer close(r.ReApplyChan)
+	defer close(r.ApplyChan)
 
 	glog.Infof("Timeout for this current run is %s", r.runTimeout.String())
-	timeout := time.NewTimer(r.runTimeout)
-	defer timeout.Stop()
+	timeoutTimer := time.NewTimer(r.runTimeout)
+	defer timeoutTimer.Stop()
 
 	go r.api.ListenAndServe()
 
@@ -90,14 +88,14 @@ func (r *Runtime) Run() error {
 
 	// TODO check the state of p8s-kubelet.service few seconds after: because it doesn't use sd_notify(3)
 
-	probeChan := time.NewTicker(time.Second * 2)
-	defer probeChan.Stop()
+	probeTick := time.NewTicker(time.Second * 2)
+	defer probeTick.Stop()
 
-	displayChan := time.NewTicker(time.Second * 2)
-	defer displayChan.Stop()
+	displayTick := time.NewTicker(time.Second * 2)
+	defer displayTick.Stop()
 
-	readinessChan := time.NewTicker(time.Second * 1)
-	defer readinessChan.Stop()
+	readinessTick := time.NewTicker(time.Second * 1)
+	defer readinessTick.Stop()
 
 	sigStopChan := make(chan os.Signal, 2)
 	defer close(sigStopChan)
@@ -111,11 +109,11 @@ func (r *Runtime) Run() error {
 			signal.Reset(syscall.SIGTERM, syscall.SIGINT)
 			return r.Stop()
 
-		case <-timeout.C:
+		case <-timeoutTimer.C:
 			glog.Warningf("Timeout %s reached, stopping ...", r.runTimeout.String())
 			r.SigChan <- syscall.SIGTERM
 
-		case <-probeChan.C:
+		case <-probeTick.C:
 			err = r.httpProbe(kubeletProbeURL)
 			if err == nil {
 				continue
@@ -133,10 +131,10 @@ func (r *Runtime) Run() error {
 			r.state.incKubeletProbeFail()
 			glog.Warningf("Kubelet probe threshold is %d/%d", failures+1, appProbeThreshold)
 
-		case <-displayChan.C:
+		case <-displayTick.C:
 			r.runDisplay()
 
-		case <-r.ReApplyChan:
+		case <-r.ApplyChan:
 			if !r.state.IsReady() {
 				glog.Warningf("Cannot re-apply when not ready, retry later")
 				continue
@@ -163,7 +161,7 @@ func (r *Runtime) Run() error {
 				glog.Errorf("Cannot apply manifests in %s", r.env.GetManifestsABSPathToApply())
 			}
 
-		case <-readinessChan.C:
+		case <-readinessTick.C:
 			if r.state.IsReady() {
 				// In case of lags during the kubectl apply
 				continue
@@ -178,14 +176,14 @@ func (r *Runtime) Run() error {
 			err := r.applyManifests()
 			if err != nil {
 				// TODO do we trigger an exit at some point
-				// TODO because it's almost a deadlock if the user didn't set a short --timeout
+				// TODO because it's almost a deadlock if the user didn't set a short --timeoutTimer
 				glog.Errorf("Cannot apply manifests in %s", r.env.GetManifestsABSPathToApply())
 				continue
 			}
 			// Mark the current state as ready
 			r.state.setReady()
 			glog.V(2).Infof("Pupernetes is ready")
-			readinessChan.Stop()
+			readinessTick.Stop()
 		}
 	}
 }

--- a/pkg/run/stop.go
+++ b/pkg/run/stop.go
@@ -35,8 +35,8 @@ func (r *Runtime) isAPIServerHookDone() bool {
 	return r.state.ready
 }
 
-func (r *Runtime) gracefulDeleteManifests() error {
-	glog.Infof("Graceful deleting API manifests ...")
+func (r *Runtime) gracefulDeleteAPIResources() error {
+	glog.Infof("Graceful deleting API resources ...")
 	ns, err := r.getNamespaces()
 	if err == nil {
 		r.DeleteAPIManifests(ns)
@@ -66,7 +66,7 @@ func (r *Runtime) gracefulDeleteManifests() error {
 			glog.V(3).Infof("Kubelet still reports %d API Pods", len(stillRunningPods)-len(staticPods))
 
 		case <-timeout.C:
-			err := fmt.Errorf("timeout reached during delete manifests")
+			err := fmt.Errorf("timeout reached during delete API resources")
 			glog.Errorf("Unexpected %v", err)
 			return err
 		}
@@ -81,7 +81,7 @@ func (r *Runtime) drainingPods() error {
 	}
 	glog.Infof("Draining kubelet's pods ...")
 
-	err := r.gracefulDeleteManifests()
+	err := r.gracefulDeleteAPIResources()
 	if err != nil {
 		glog.Warningf("Failed to handle a graceful delete of API resources: %v", err)
 	}


### PR DESCRIPTION
### What does this PR do?

All the already existing commands are under the `daemon` sub commands.
Introduce the `reset`command to reset Kubernetes namespaces and re-deploy the initial manifests.

### Motivation

Ease the flow when running multiple argo workflows.
This allows to not implementing the deletion in each argo workflow.

```bash
pupernetes reset default
```

The default namespace can also be reset with:
```bash
pupernetes reset kube-system --apply
```

All namespaces can also be reset with:
```bash
pupernetes reset $(kubectl get ns -o name) --apply
```

Or with a SIGSTP:
```
sudo ./pupernetes daemon run sandbox/
I0605 12:10:29.656861   10858 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/etcd-data
I0605 12:10:29.657341   10858 clean.go:32] Removed /var/lib/p8s-kubelet
I0605 12:10:29.657991   10858 clean.go:32] Removed /var/log/pods/
I0605 12:10:29.658005   10858 clean.go:144] Cleanup successfully finished
I0605 12:10:29.728060   10858 hostname.go:59] Using hostname: "v1704"
I0605 12:10:29.899344   10858 systemd.go:108] Already created systemd unit: p8s-kubelet.service, untouched
I0605 12:10:29.899458   10858 systemd.go:108] Already created systemd unit: p8s-etcd.service, untouched
I0605 12:10:32.585274   10858 setup.go:264] Setup ready /home/jb/go/src/github.com/DataDog/pupernetes/sandbox
I0605 12:10:32.585569   10858 run.go:76] Timeout for this current run is 6h0m0s
I0605 12:10:32.585642   10858 systemd.go:40] Starting systemd unit: p8s-etcd.service ...
I0605 12:10:32.951535   10858 systemd.go:40] Starting systemd unit: p8s-kubelet.service ...
I0605 12:10:33.954525   10858 state.go:38] Kubenertes apiserver not ready yet: Get http://127.0.0.1:8080/healthz: dial tcp 127.0.0.1:8080: connect: connection refused
I0605 12:10:36.955732   10858 state.go:68] Kubelet log reports 1 running pods
I0605 12:10:38.954640   10858 state.go:77] Kube apiserver restart count: 2
I0605 12:10:41.957123   10858 state.go:38] Kubenertes apiserver not ready yet: bad status code for http://127.0.0.1:8080/healthz: 500
I0605 12:10:44.956694   10858 kubectl.go:14] Calling kubectl apply -f /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-api ...
I0605 12:10:45.384859   10858 kubectl.go:21] Successfully applied manifests:
serviceaccount "coredns" created
clusterrole.rbac.authorization.k8s.io "system:coredns" created
clusterrolebinding.rbac.authorization.k8s.io "system:coredns" created
configmap "coredns" created
deployment.extensions "coredns" created
service "coredns" created
serviceaccount "kube-controller-manager" created
pod "kube-controller-manager" created
daemonset.extensions "kube-proxy" created
daemonset.extensions "kube-scheduler" created
clusterrolebinding.rbac.authorization.k8s.io "p8s-admin" created
I0605 12:10:45.384915   10858 run.go:187] Pupernetes is ready
I0605 12:10:46.955585   10858 state.go:68] Kubelet log reports 2 running pods
I0605 12:10:46.972436   10858 state.go:59] Kubelet API reports 2 running pods
I0605 12:10:52.954998   10858 state.go:68] Kubelet log reports 4 running pods
I0605 12:10:52.966961   10858 state.go:59] Kubelet API reports 4 running pods
I0605 12:10:56.955074   10858 state.go:68] Kubelet log reports 5 running pods
I0605 12:10:58.967959   10858 state.go:59] Kubelet API reports 5 running pods
^ZI0605 12:11:07.142576   10858 stop.go:39] Graceful deleting API resources ...
I0605 12:11:14.546302   10858 delete.go:308] Graceful deleted API resources in 3 namespaces
I0605 12:11:15.558582   10858 stop.go:63] Kubelet run only 1 static pods
I0605 12:11:15.558618   10858 kubectl.go:14] Calling kubectl apply -f /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-api ...
I0605 12:11:15.808964   10858 kubectl.go:21] Successfully applied manifests:
serviceaccount "coredns" created
clusterrole.rbac.authorization.k8s.io "system:coredns" configured
clusterrolebinding.rbac.authorization.k8s.io "system:coredns" configured
configmap "coredns" created
deployment.extensions "coredns" created
service "coredns" created
serviceaccount "kube-controller-manager" created
pod "kube-controller-manager" created
daemonset.extensions "kube-proxy" created
daemonset.extensions "kube-scheduler" created
clusterrolebinding.rbac.authorization.k8s.io "p8s-admin" configured
I0605 12:11:15.809147   10858 state.go:68] Kubelet log reports 6 running pods
I0605 12:11:15.811297   10858 state.go:59] Kubelet API reports 1 running pods
I0605 12:11:16.954797   10858 state.go:68] Kubelet log reports 7 running pods
I0605 12:11:16.955950   10858 state.go:59] Kubelet API reports 2 running pods
I0605 12:11:20.954561   10858 state.go:68] Kubelet log reports 9 running pods
I0605 12:11:22.973927   10858 state.go:59] Kubelet API reports 3 running pods
I0605 12:11:24.966890   10858 state.go:59] Kubelet API reports 4 running pods
I0605 12:11:26.956232   10858 state.go:68] Kubelet log reports 10 running pods
I0605 12:11:28.969679   10858 state.go:59] Kubelet API reports 5 running pods
I0605 12:11:34.955346   10858 state.go:68] Kubelet log reports 5 running pods
```