### PR TITLE
New wait command

### DIFF
--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -224,8 +224,18 @@ func NewCommand() (*cobra.Command, *int) {
 		SuggestFor: []string{"tail", "watch"},
 		Use:        "wait a systemd unit",
 		Aliases:    []string{"w"},
-		Short:      "Wait for systemd unit name to be Running",
+		Short:      `Wait for a systemd unit to be "running"`,
 		Args:       cobra.ExactArgs(0),
+		Example: fmt.Sprintf(`
+# Wait until the pupernetes.service systemd unit is running:
+%s wait
+
+# Wait until the p8s-kubelet.service systemd unit is running:
+%s wait -u p8s-kubelet
+`,
+			programName,
+			programName,
+		),
 		Run: func(cmd *cobra.Command, args []string) {
 			unitToWatch := config.ViperConfig.GetString("unit-to-watch")
 			if unitToWatch == "" {

--- a/docs/pupernetes.md
+++ b/docs/pupernetes.md
@@ -17,4 +17,5 @@ Use this command to manage a Kubernetes local environment
 
 * [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
 * [pupernetes reset](pupernetes_reset.md)	 - Reset the Kubernetes resources in the given namespace
+* [pupernetes wait](pupernetes_wait.md)	 - Wait for systemd unit name to be Running
 

--- a/docs/pupernetes.md
+++ b/docs/pupernetes.md
@@ -17,5 +17,5 @@ Use this command to manage a Kubernetes local environment
 
 * [pupernetes daemon](pupernetes_daemon.md)	 - Use this command to clean setup and run a Kubernetes local environment
 * [pupernetes reset](pupernetes_reset.md)	 - Reset the Kubernetes resources in the given namespace
-* [pupernetes wait](pupernetes_wait.md)	 - Wait for systemd unit name to be Running
+* [pupernetes wait](pupernetes_wait.md)	 - Wait for a systemd unit to be "running"
 

--- a/docs/pupernetes_wait.md
+++ b/docs/pupernetes_wait.md
@@ -1,0 +1,30 @@
+## pupernetes wait
+
+Wait for systemd unit name to be Running
+
+### Synopsis
+
+Wait for systemd unit name to be Running
+
+```
+pupernetes wait [systemd unit name] [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for wait
+      --logging-since duration   Display the logs of the unit since (default 5m0s)
+      --timeout duration         Timeout for wait (default 6h0m0s)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose int   verbose level (default 2)
+```
+
+### SEE ALSO
+
+* [pupernetes](pupernetes.md)	 - Use this command to manage a Kubernetes local environment
+

--- a/docs/pupernetes_wait.md
+++ b/docs/pupernetes_wait.md
@@ -7,7 +7,7 @@ Wait for systemd unit name to be Running
 Wait for systemd unit name to be Running
 
 ```
-pupernetes wait [systemd unit name] [flags]
+pupernetes wait a systemd unit [flags]
 ```
 
 ### Options
@@ -15,7 +15,8 @@ pupernetes wait [systemd unit name] [flags]
 ```
   -h, --help                     help for wait
       --logging-since duration   Display the logs of the unit since (default 5m0s)
-      --timeout duration         Timeout for wait (default 6h0m0s)
+      --timeout duration         Timeout for wait (default 15m0s)
+  -u, --unit-to-watch string     Systemd unit name to watch (default "pupernetes.service")
 ```
 
 ### Options inherited from parent commands

--- a/docs/pupernetes_wait.md
+++ b/docs/pupernetes_wait.md
@@ -1,13 +1,25 @@
 ## pupernetes wait
 
-Wait for systemd unit name to be Running
+Wait for a systemd unit to be "running"
 
 ### Synopsis
 
-Wait for systemd unit name to be Running
+Wait for a systemd unit to be "running"
 
 ```
 pupernetes wait a systemd unit [flags]
+```
+
+### Examples
+
+```
+
+# Wait until the pupernetes.service systemd unit is running:
+pupernetes wait
+
+# Wait until the p8s-kubelet.service systemd unit is running:
+pupernetes wait -u p8s-kubelet
+
 ```
 
 ### Options

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,4 +45,6 @@ func init() {
 	ViperConfig.SetDefault("systemd-job-name", "pupernetes")
 
 	ViperConfig.SetDefault("apply", false)
+
+	ViperConfig.SetDefault("logging-since", time.Minute*5)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,4 +47,5 @@ func init() {
 	ViperConfig.SetDefault("apply", false)
 
 	ViperConfig.SetDefault("logging-since", time.Minute*5)
+	ViperConfig.SetDefault("unit-to-watch", "pupernetes.service")
 }

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -16,7 +16,7 @@ type Wait struct {
 
 func NewWaiter(systemdUnitName string, timeout, loggingSince time.Duration) *Wait {
 	if !strings.HasSuffix(systemdUnitName, ".service") {
-		systemdUnitName = ".service"
+		systemdUnitName = systemdUnitName + ".service"
 	}
 	return &Wait{
 		systemdUnitName: systemdUnitName,

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -1,0 +1,96 @@
+package wait
+
+import (
+	"fmt"
+	"github.com/DataDog/pupernetes/pkg/logging"
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/golang/glog"
+	"strings"
+	"time"
+)
+
+type Wait struct {
+	systemdUnitName       string
+	timeout, loggingSince time.Duration
+}
+
+func NewWaiter(systemdUnitName string, timeout, loggingSince time.Duration) *Wait {
+	if !strings.HasSuffix(systemdUnitName, ".service") {
+		systemdUnitName = ".service"
+	}
+	return &Wait{
+		systemdUnitName: systemdUnitName,
+		timeout:         timeout,
+		loggingSince:    loggingSince,
+	}
+}
+
+func getSystemdUnitState(conn *dbus.Conn, unitName string) (string, error) {
+	units, err := conn.ListUnitsByNames([]string{unitName})
+	if err != nil {
+		glog.Errorf("Cannot list units: %v", err)
+		return "", err
+	}
+	if len(units) == 0 {
+		err := fmt.Errorf("cannot find %s systemd unit", unitName)
+		glog.Errorf("Empty result: %v", err)
+		return "", err
+	}
+	if len(units) != 1 {
+		err := fmt.Errorf("invalid number of systemd unit: %d", len(units))
+		glog.Errorf("Too much results: %v", err)
+		return "", err
+	}
+	glog.V(4).Infof("%s sub state is %s", units[0].Name, units[0].SubState)
+	return units[0].SubState, nil
+}
+
+func (w *Wait) Wait() error {
+	conn, err := dbus.NewSystemdConnection()
+	if err != nil {
+		glog.Errorf("Cannot connect to dbus: %v", err)
+		return err
+	}
+	defer conn.Close()
+
+	ts := time.Now().Add(-w.loggingSince)
+	jt, err := logging.NewJournalTailer(w.systemdUnitName, ts, true)
+	if err != nil {
+		glog.Errorf("Cannot start the journal tailer on %s: %v", w.systemdUnitName, err)
+		return err
+	}
+	defer jt.StopTail()
+	err = jt.StartTail()
+	if err != nil {
+		glog.Errorf("Cannot start journal tailing: %v", err)
+		return err
+	}
+	timeout := time.NewTimer(w.timeout)
+	defer timeout.Stop()
+
+	tick := time.NewTicker(time.Second * 3)
+	defer tick.Stop()
+	for {
+		select {
+		case <-timeout.C:
+			err := fmt.Errorf("timeout while waiting for %s systemd unit", w.systemdUnitName)
+			glog.Errorf("Unexpected timeout: %v", err)
+			return err
+
+		case <-tick.C:
+			state, err := getSystemdUnitState(conn, w.systemdUnitName)
+			if err != nil {
+				return err
+			}
+			if state == "running" {
+				glog.Infof("Systemd unit %s is %s", w.systemdUnitName, state)
+				return nil
+			}
+			if state == "dead" {
+				err = fmt.Errorf("systemd job %s is %s", w.systemdUnitName, state)
+				glog.Errorf("Unexpected state of systemd job: %v", err)
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This new command remove any logic like: 
```bash
until curl -sf http://127.0.0.1:8989/ready --connect-timeout 1 -w '\n'
do
    systemctl status pupernetes.service --no-pager --full
    journalctl -u pupernetes.service --no-pager -o cat -n 50 -e

    sleep 10
done
```
to be used like:
```bash
pupernetes wait pupernetes.service
```
This will nicely tail the associated journald entry without any duplicate.
```text
[pupernetes.service] Starting github.com/DataDog/pupernetes...
[pupernetes.service] I0607 18:05:25.886126   27882 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sanbox/etcd-data
[pupernetes.service] I0607 18:05:25.886537   27882 clean.go:32] Removed /var/lib/p8s-kubelet
[pupernetes.service] I0607 18:05:25.886567   27882 clean.go:32] Removed /var/log/pods/
[pupernetes.service] I0607 18:05:25.886572   27882 clean.go:163] Cleanup finished
[pupernetes.service] I0607 18:05:25.924006   27882 hostname.go:59] Using hostname: "v1704"
[pupernetes.service] I0607 18:05:26.077163   27882 manifests.go:94] Using template collection of Kubernetes 1.10
[pupernetes.service] I0607 18:05:26.081590   27882 systemd.go:111] Already created systemd unit: p8s-etcd.service, untouched
[pupernetes.service] I0607 18:05:26.081739   27882 systemd.go:111] Already created systemd unit: p8s-kubelet.service, untouched
[pupernetes.service] I0607 18:05:26.082105   27882 systemd.go:111] Already created systemd unit: p8s-kube-apiserver.service, untouched
[pupernetes.service] I0607 18:05:28.600064   27882 setup.go:294] Setup ready /home/jb/go/src/github.com/DataDog/pupernetes/sanbox
[pupernetes.service] I0607 18:05:28.601200   27882 run.go:78] Timeout for this current run is 6h0m0s
[pupernetes.service] I0607 18:05:28.601243   27882 systemd_action.go:41] Starting systemd unit: p8s-etcd.service ...
[pupernetes.service] I0607 18:05:28.607118   27882 systemd_action.go:41] Starting systemd unit: p8s-kubelet.service ...
[pupernetes.service] I0607 18:05:28.611777   27882 systemd_action.go:41] Starting systemd unit: p8s-kube-apiserver.service ...
[pupernetes.service] I0607 18:05:29.614882   27882 state.go:36] Kubenertes apiserver not ready yet: Get http://127.0.0.1:8080/healthz: dial tcp 127.0.0.1:8080: connect: connection refused
[pupernetes.service] I0607 18:05:32.623306   27882 state.go:36] Kubenertes apiserver not ready yet: bad status code for http://127.0.0.1:8080/healthz: 500
[pupernetes.service] I0607 18:05:36.617347   27882 kubectl.go:14] Calling kubectl apply -f /home/jb/go/src/github.com/DataDog/pupernetes/sanbox/manifest-api ...
[pupernetes.service] I0607 18:05:37.597395   27882 kubectl.go:21] Successfully applied manifests:
[pupernetes.service] serviceaccount "coredns" created
[pupernetes.service] clusterrole.rbac.authorization.k8s.io "system:coredns" created
[pupernetes.service] clusterrolebinding.rbac.authorization.k8s.io "system:coredns" created
[pupernetes.service] configmap "coredns" created
[pupernetes.service] deployment.extensions "coredns" created
[pupernetes.service] service "coredns" created
[pupernetes.service] serviceaccount "kube-controller-manager" created
[pupernetes.service] pod "kube-controller-manager" created
[pupernetes.service] daemonset.extensions "kube-proxy" created
[pupernetes.service] daemonset.extensions "kube-scheduler" created
[pupernetes.service] clusterrolebinding.rbac.authorization.k8s.io "p8s-admin" created
[pupernetes.service] I0607 18:05:37.597553   27882 notify.go:39] Compiled with CGO_ENABLED=0, unable to ack the systemd notify. PPID is 1
[pupernetes.service] I0607 18:05:37.597567   27882 run.go:190] Pupernetes is ready
[pupernetes.service] Started github.com/DataDog/pupernetes.
[pupernetes.service] I0607 18:05:38.617325   27882 state.go:66] Kubelet log reports 1 running pods
I0607 18:05:39.207790   27645 wait.go:86] Systemd unit pupernetes.service is running
```
### Motivation

The bash logic produce too much log lines and can saturate the output of the CI.

