### PR TITLE
Use a more portable version of listUnits

### DIFF
--- a/pkg/job/systemd.go
+++ b/pkg/job/systemd.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/pupernetes/pkg/config"
 	"github.com/DataDog/pupernetes/pkg/logging"
+	"github.com/DataDog/pupernetes/pkg/util"
 )
 
 const (
@@ -65,7 +66,7 @@ func RunSystemdJob(givenRootPath string) error {
 	if !strings.HasSuffix(unitName, ".service") {
 		unitName = unitName + ".service"
 	}
-	units, err := dbus.ListUnitsByNames([]string{unitName})
+	units, err := util.GetUnitStates(dbus, []string{unitName})
 	if err != nil {
 		glog.Errorf("Cannot get the status of %s: %v", unitName, err)
 		return err

--- a/pkg/run/probe.go
+++ b/pkg/run/probe.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"github.com/DataDog/pupernetes/pkg/util"
 	"github.com/golang/glog"
 	"io/ioutil"
 	"net/http"
@@ -31,7 +32,7 @@ func (r *Runtime) httpProbe(url string) error {
 }
 
 func (r *Runtime) probeUnitStatuses() ([]string, error) {
-	units, err := r.env.GetDBUSClient().ListUnitsByNames(r.env.GetSystemdUnits())
+	units, err := util.GetUnitStates(r.env.GetDBUSClient(), r.env.GetSystemdUnits())
 	if err != nil {
 		glog.Errorf("Unexpected error: %v", err)
 		return nil, err
@@ -39,7 +40,7 @@ func (r *Runtime) probeUnitStatuses() ([]string, error) {
 	var failed []string
 	for _, u := range units {
 		s := fmt.Sprintf("unit %q with load state %q is %q", u.Name, u.LoadState, u.SubState)
-		glog.V(3).Infof("%s", s)
+		glog.V(3).Infof("Current state: %s", s)
 		switch u.SubState {
 		case "running":
 			continue

--- a/pkg/setup/manifests.go
+++ b/pkg/setup/manifests.go
@@ -59,6 +59,11 @@ func (e *Environment) renderTemplates(category string) error {
 		return err
 	}
 	glog.V(4).Infof("Rendering templates with the following metadata: %v", string(b))
+	prefix := ""
+	if category == defaultTemplates.ManifestSystemdUnit {
+		prefix = e.systemdUnitPrefix
+		glog.V(4).Infof("Currently rendering %s with file prefix %q", category, prefix)
+	}
 	for _, f := range files {
 		p := path.Join(sourceDir, f.Name())
 
@@ -73,7 +78,7 @@ func (e *Environment) renderTemplates(category string) error {
 			return err
 		}
 
-		destPath := path.Join(e.rootABSPath, category, f.Name())
+		destPath := path.Join(e.rootABSPath, category, prefix+f.Name())
 		glog.V(4).Infof("Rendering manifest %s to %s", f.Name(), destPath)
 		dest, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0444)
 		if err != nil {

--- a/pkg/setup/systemd.go
+++ b/pkg/setup/systemd.go
@@ -178,17 +178,16 @@ func (e *Environment) createEnd2EndSection() []*unit2.UnitOption {
 }
 
 func (e *Environment) createUnitFromTemplate(unitName string) error {
-	unitNameNoPrefix := strings.TrimPrefix(unitName, e.systemdUnitPrefix)
-	manifestUnitName := path.Join(e.manifestSystemdUnit, unitNameNoPrefix)
+	manifestUnitName := path.Join(e.manifestSystemdUnit, unitName)
 	fd, err := os.OpenFile(manifestUnitName, os.O_RDONLY, 0)
 	if err != nil {
-		glog.Errorf("Cannot read %s: %v", unitNameNoPrefix, err)
+		glog.Errorf("Cannot read %s: %v", manifestUnitName, err)
 		return err
 	}
 	defer fd.Close()
 	unitOptions, err := unit2.Deserialize(fd)
 	if err != nil {
-		glog.Errorf("Unexpected error during parsing s: %v", unitNameNoPrefix, err)
+		glog.Errorf("Unexpected error during parsing s: %v", manifestUnitName, err)
 		return err
 	}
 	// TODO see how to insert e.systemdEnd2EndSection

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"fmt"
 	"github.com/DataDog/pupernetes/pkg/logging"
+	"github.com/DataDog/pupernetes/pkg/util"
 	"github.com/coreos/go-systemd/dbus"
 	"github.com/golang/glog"
 	"strings"
@@ -26,7 +27,7 @@ func NewWaiter(systemdUnitName string, timeout, loggingSince time.Duration) *Wai
 }
 
 func getSystemdUnitState(conn *dbus.Conn, unitName string) (string, error) {
-	units, err := conn.ListUnitsByNames([]string{unitName})
+	units, err := util.GetUnitStates(conn, []string{unitName})
 	if err != nil {
 		glog.Errorf("Cannot list units: %v", err)
 		return "", err
@@ -82,6 +83,7 @@ func (w *Wait) Wait() error {
 			if err != nil {
 				return err
 			}
+			glog.V(4).Infof("Systemd unit %s is %s", w.systemdUnitName, state)
 			if state == "running" {
 				glog.Infof("Systemd unit %s is %s", w.systemdUnitName, state)
 				return nil


### PR DESCRIPTION
### What does this PR do?

The method `ListUnitsByNames` only supports a systemd >= 230.
See https://github.com/coreos/go-systemd/issues/223

I used the generic ListUnits and @xvello tested it on systemd 229 👍 

I also added the systemd prefix to the units in the manifests:
```
sandbox/manifest-systemd-unit/p8s-etcd.service
sandbox/manifest-systemd-unit/p8s-kube-apiserver.service
sandbox/manifest-systemd-unit/p8s-kubelet.service
```
 Because the link in `/run/systemd/system/p8s-kubelet.service` -> `~/sandbox/manifest-systemd-unit/kubelet.service`

Give an unit name `kubelet.service` instead of `p8s-kubelet.service`
