### PR TITLE
Add notify to the systemd unit

### DIFF
--- a/environments/container-linux/ignition.yaml
+++ b/environments/container-linux/ignition.yaml
@@ -52,6 +52,7 @@ systemd:
       ExecStart=/opt/bin/pupernetes daemon run /opt/sandbox --kubectl-link /opt/bin/kubectl -v 5 --timeout 6h
       Restart=on-failure
       RestartSec=5
+      Type=notify
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Set by default the systemd notify in the unit.

### Motivation

Needed by `pupernetes wait` possible with #16 #34 
 
