### PR TITLE
Use RSA standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Executables in PATH:
 * unzip
 * systemctl
 * systemd-resolve (or a non-systemd managed `/etc/resolv.conf`)
-* openssl
 * mount
 
 Any implicit requirements for the **kubelet** like the container runtime and [more](https://github.com/kubernetes/kubernetes/issues/26093)

--- a/pkg/setup/requirements.go
+++ b/pkg/setup/requirements.go
@@ -39,10 +39,6 @@ func checkRequirements() error {
 	if err != nil {
 		return err
 	}
-	err = checkCommand("openssl", "genrsa")
-	if err != nil {
-		return err
-	}
 	conn, err := dbus.NewSystemdConnection()
 	if err != nil {
 		glog.Errorf("Cannot connect to dbus: %v", err)


### PR DESCRIPTION
#51 

### What does this PR do?

Use Go's RSA standard library instead of executing `openssl`.

### Motivation

Less dependencies.

