### PR TITLE
Enable HPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,6 @@ You can have a look at which metrics are available [here](./docs/metrics.csv).
 * Secrets
   * IP SAN
     * Statically configured with the given Kubernetes cluster IP range
+* Support for Custom Metrics
+  * You can register an API Service for an External Metrics Provider.
+  This is only supported for 1.10.x and 1.11.x.

--- a/pkg/setup/templates/1.10.go
+++ b/pkg/setup/templates/1.10.go
@@ -71,6 +71,13 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--service-account-key-file={{.RootABSPath}}/secrets/service-accounts.rsa \
 	--kubelet-client-certificate={{.RootABSPath}}/secrets/kubernetes.certificate \
 	--kubelet-client-key={{.RootABSPath}}/secrets/kubernetes.private_key \
+	--requestheader-client-ca-file={{.RootABSPath}}/secrets/kube-controller-manager.bundle \
+	--requestheader-allowed-names=aggregator,e2e,p8s \
+	--requestheader-extra-headers-prefix=X-Remote-Extra- \
+	--requestheader-group-headers=X-Remote-Group \
+	--requestheader-username-headers=X-Remote-User \
+	--proxy-client-cert-file={{.RootABSPath}}/secrets/kubernetes.certificate \
+	--proxy-client-key-file={{.RootABSPath}}/secrets/kubernetes.private_key \
 	--kubelet-https \
 	--kubelet-certificate-authority={{.RootABSPath}}/secrets/kubernetes.issuing_ca \
 	--target-ram-mb=0 \
@@ -220,6 +227,7 @@ spec:
     - --concurrent-resource-quota-syncs=2
     - --concurrent-service-syncs=1
     - --concurrent-serviceaccount-token-syncs=2
+    - --horizontal-pod-autoscaler-use-rest-clients=true
     volumeMounts:
       - name: secrets
         mountPath: /etc/secrets

--- a/pkg/setup/templates/1.11.go
+++ b/pkg/setup/templates/1.11.go
@@ -71,6 +71,13 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--kubelet-client-certificate={{.RootABSPath}}/secrets/kubernetes.certificate \
 	--kubelet-client-key={{.RootABSPath}}/secrets/kubernetes.private_key \
 	--kubelet-https \
+	--requestheader-client-ca-file={{.RootABSPath}}/secrets/kube-controller-manager.bundle \
+	--requestheader-allowed-names=aggregator,e2e,p8s \
+	--requestheader-extra-headers-prefix=X-Remote-Extra- \
+	--requestheader-group-headers=X-Remote-Group \
+	--requestheader-username-headers=X-Remote-User \
+	--proxy-client-cert-file={{.RootABSPath}}/secrets/kubernetes.certificate \
+	--proxy-client-key-file={{.RootABSPath}}/secrets/kubernetes.private_key \
 	--kubelet-certificate-authority={{.RootABSPath}}/secrets/kubernetes.issuing_ca \
 	--target-ram-mb=0 \
 	--watch-cache=false \
@@ -219,6 +226,7 @@ spec:
     - --concurrent-resource-quota-syncs=2
     - --concurrent-service-syncs=1
     - --concurrent-serviceaccount-token-syncs=2
+    - --horizontal-pod-autoscaler-use-rest-clients=true
     volumeMounts:
       - name: secrets
         mountPath: /etc/secrets


### PR DESCRIPTION
### What does this PR do?

Specifying flags to enable the registering and support of Metrics Server and Custom/External Metrics Provider.

### Motivation

Create an HPA ready cluster locally. Allow to register the EM providers.

### Additional notes

Verified for:
- [x] 1.11
- [x] 1.10