### PR TITLE
Introduce sonobuoy in CI

### DIFF
--- a/.ci/sonobuoy.sh
+++ b/.ci/sonobuoy.sh
@@ -8,9 +8,15 @@ curl -L https://github.com/heptio/sonobuoy/releases/download/v0.11.3/sonobuoy_0.
 tar -xzvf sonobuoy.tar.gz
 rm -v sonobuoy.tar.gz
 
-./sonobuoy run --mode Quick --skip-preflight
-
 set +e
+while true
+do
+    kubectl get po kube-controller-manager -n kube-system -o json | jq -re '. | select(.status.phase=="Running")' && break
+    sleep 5
+done
+
+./sonobuoy run --mode Quick --skip-preflight || exit $?
+
 until ./sonobuoy status
 do
     sleep 10

--- a/.ci/sonobuoy.sh
+++ b/.ci/sonobuoy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+cd $(dirname $0)
+
+curl -L https://github.com/heptio/sonobuoy/releases/download/v0.11.3/sonobuoy_0.11.3_linux_amd64.tar.gz -o sonobuoy.tar.gz
+tar -xzvf sonobuoy.tar.gz
+rm -v sonobuoy.tar.gz
+
+./sonobuoy run --mode Quick --skip-preflight
+
+set +e
+until ./sonobuoy status
+do
+    sleep 10
+done
+
+while true
+do
+    SSTATUS=$(./sonobuoy status)
+    echo ${SSTATUS} | grep -c "Sonobuoy has completed" && break
+    sleep 10
+done
+set -e
+
+./sonobuoy status
+
+until ls -l *_sonobuoy_*.tar.gz
+do
+    sleep 2
+    ./sonobuoy status
+    ./sonobuoy retrieve
+done
+
+./sonobuoy e2e *_sonobuoy_*.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ templates:
       CFLAGS: ""
       CGO_ENABLED: "1"
       DEBIAN_FRONTEND: "noninteractive"
+      SUDO_USER: "circleci"
 
 jobs:
   make:
@@ -151,8 +152,8 @@ jobs:
           command: kubectl get no,svc,deploy,ds,job,po --all-namespaces -o wide
 
       - run:
-          name: validate
-          command: kubectl apply -f .ci/pupernetes-validation.yaml
+          name: sonobuoy
+          command: ./.ci/sonobuoy.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,12 @@ jobs:
       - run:
           name: make
           command: make
-
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
+      - run:
+          name: kubeconfig
+          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config
 
       - run:
           name: setup
@@ -109,10 +111,12 @@ jobs:
       - run:
           name: make
           command: make
-
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
+      - run:
+          name: kubeconfig
+          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config
 
       - run:
           name: setup
@@ -138,10 +142,12 @@ jobs:
       - run:
           name: make
           command: make
-
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
+      - run:
+          name: kubeconfig
+          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config
 
       - run:
           name: run
@@ -149,7 +155,8 @@ jobs:
 
       - run:
           name: kubectl
-          command: kubectl get no,svc,deploy,ds,job,po --all-namespaces -o wide
+          # kubectl some stuff
+          command: kubectl config view && kubectl version && kubectl get no,svc,deploy,ds,job,po --all-namespaces -o wide
 
       - run:
           name: sonobuoy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,22 +81,22 @@ jobs:
 
       - run:
           name: setup
-          command: sudo ./pupernetes daemon setup sandbox/ -v 5
+          command: sudo ./pupernetes daemon setup sandbox/ -v 5 --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: already-setup
           # As it's already setup, pupernetes should be very fast
-          command: sudo timeout 15 ./pupernetes daemon setup sandbox/
+          command: sudo timeout 15 ./pupernetes daemon setup sandbox/ --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: clean-setup
           # As we kept the binaries, pupernetes should be very fast
-          command: sudo timeout 15 ./pupernetes daemon setup sandbox/ -c etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets
+          command: sudo timeout 15 ./pupernetes daemon setup sandbox/ -c etcd,iptables,kubectl,kubelet,manifests,mounts,network,secrets --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: version-setup
           # It should download and extract the hyperkube tarball and clean everything but the binaries
-          command: sudo ./pupernetes daemon setup sandbox/ --hyperkube-version 1.9.4 -c -binaries
+          command: sudo ./pupernetes daemon setup sandbox/ --hyperkube-version 1.9.4 -c -binaries --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: clean
@@ -116,16 +116,16 @@ jobs:
 
       - run:
           name: setup
-          command: sudo ./pupernetes daemon setup sandbox/ -v 5
+          command: sudo ./pupernetes daemon setup sandbox/ -v 5 --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: copy-validation
           # Copy a batch validation job where the manifests are applied once pupernetes is ready =)
-          command: sudo cp -v .ci//pupernetes-validation.yaml sandbox/manifest-api/pupernetes-validation.yaml
+          command: sudo cp -v .ci/pupernetes-validation.yaml sandbox/manifest-api/pupernetes-validation.yaml
 
       - run:
           name: run
-          command: sudo ./pupernetes daemon run sandbox/ --bind-address 0.0.0.0:8989 # TODO use https + authN/Z
+          command: sudo ./pupernetes daemon run sandbox/ --bind-address 0.0.0.0:8989 --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: clean
@@ -145,7 +145,7 @@ jobs:
 
       - run:
           name: run
-          command: sudo ./pupernetes daemon run sandbox/ --job-type systemd -v 5 --kubectl-link /usr/local/bin/kubectl --bind-address 0.0.0.0:8989
+          command: sudo ./pupernetes daemon run sandbox/ --job-type systemd -v 5 --kubectl-link /usr/local/bin/kubectl --bind-address 0.0.0.0:8989 --kubeconfig-path /home/circleci/.kube/config
 
       - run:
           name: kubectl

--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -285,6 +285,9 @@ func NewCommand() (*cobra.Command, *int) {
 	daemonCommand.PersistentFlags().String("kubectl-link", config.ViperConfig.GetString("kubectl-link"), "path to create a kubectl link")
 	config.ViperConfig.BindPFlag("kubectl-link", daemonCommand.PersistentFlags().Lookup("kubectl-link"))
 
+	daemonCommand.PersistentFlags().String("kubeconfig-path", config.ViperConfig.GetString("kubeconfig-path"), "path to the kubeconfig file")
+	config.ViperConfig.BindPFlag("kubeconfig-path", daemonCommand.PersistentFlags().Lookup("kubeconfig-path"))
+
 	daemonCommand.PersistentFlags().StringP("clean", "c", config.ViperConfig.GetString("clean"), fmt.Sprintf("clean options before %s: %s", setupCommand.Name(), options.GetOptionNames(options.Clean{})))
 	config.ViperConfig.BindPFlag("clean", daemonCommand.PersistentFlags().Lookup("clean"))
 

--- a/docs/pupernetes_daemon.md
+++ b/docs/pupernetes_daemon.md
@@ -14,6 +14,7 @@ Use this command to clean setup and run a Kubernetes local environment
       --etcd-version string          etcd version (default "3.1.11")
   -h, --help                         help for daemon
       --hyperkube-version string     hyperkube version (default "1.10.3")
+      --kubeconfig-path string       path to the kubeconfig file
       --kubectl-link string          path to create a kubectl link
       --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
       --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")

--- a/docs/pupernetes_daemon_clean.md
+++ b/docs/pupernetes_daemon_clean.md
@@ -38,6 +38,7 @@ pupernetes daemon clean state/ -c etcd,network,secrets
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.3")
+      --kubeconfig-path string       path to the kubeconfig file
       --kubectl-link string          path to create a kubectl link
       --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
       --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -55,6 +55,7 @@ pupernetes daemon run state/ --job-type systemd
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.3")
+      --kubeconfig-path string       path to the kubeconfig file
       --kubectl-link string          path to create a kubectl link
       --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
       --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")

--- a/docs/pupernetes_daemon_setup.md
+++ b/docs/pupernetes_daemon_setup.md
@@ -29,6 +29,7 @@ pupernetes daemon setup state/
       --cni-version string           container network interface (cni) version (default "0.7.0")
       --etcd-version string          etcd version (default "3.1.11")
       --hyperkube-version string     hyperkube version (default "1.10.3")
+      --kubeconfig-path string       path to the kubeconfig file
       --kubectl-link string          path to create a kubectl link
       --kubelet-root-dir string      directory path for managing kubelet files (default "/var/lib/p8s-kubelet")
       --systemd-unit-prefix string   prefix for systemd unit name (default "p8s-")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,4 +58,5 @@ func init() {
 	ViperConfig.SetDefault("unit-to-watch", "pupernetes.service")
 	ViperConfig.SetDefault("wait-timeout", time.Minute*15)
 	ViperConfig.SetDefault("client-timeout", time.Minute*1)
+	ViperConfig.SetDefault("kubeconfig-path", "")
 }

--- a/pkg/setup/kubeclient.go
+++ b/pkg/setup/kubeclient.go
@@ -30,15 +30,13 @@ func getHome() string {
 }
 
 func (e *Environment) setupKubectl() error {
-	kubeDirPath := path.Join(getHome(), ".kube")
-	kubeConfigPath := path.Join(kubeDirPath, "config")
-	glog.V(4).Infof("Building kubectl configuration in %s ...", kubeConfigPath)
+	glog.V(4).Infof("Building kubectl configuration in %s ...", e.kubeConfigUserPath)
 
 	// cluster
 	b, err := exec.Command(e.GetHyperkubePath(),
 		"kubectl",
 		"config",
-		"--kubeconfig="+kubeConfigPath,
+		"--kubeconfig="+e.kubeConfigUserPath,
 		"set-cluster",
 		defaultKubectlClusterName,
 		"--server=https://127.0.0.1:6443",
@@ -55,7 +53,7 @@ func (e *Environment) setupKubectl() error {
 	b, err = exec.Command(e.GetHyperkubePath(),
 		"kubectl",
 		"config",
-		"--kubeconfig="+kubeConfigPath,
+		"--kubeconfig="+e.kubeConfigUserPath,
 		"set-credentials",
 		defaultKubectlUserName,
 		"--username="+defaultKubectlUserName,
@@ -73,7 +71,7 @@ func (e *Environment) setupKubectl() error {
 	b, err = exec.Command(e.GetHyperkubePath(),
 		"kubectl",
 		"config",
-		"--kubeconfig="+kubeConfigPath,
+		"--kubeconfig="+e.kubeConfigUserPath,
 		"set-context",
 		defaultKubectlContextName,
 		"--user="+defaultKubectlUserName,
@@ -91,7 +89,7 @@ func (e *Environment) setupKubectl() error {
 	b, err = exec.Command(e.GetHyperkubePath(),
 		"kubectl",
 		"config",
-		"--kubeconfig="+kubeConfigPath,
+		"--kubeconfig="+e.kubeConfigUserPath,
 		"use-context",
 		defaultKubectlContextName,
 	).CombinedOutput()
@@ -109,7 +107,7 @@ func (e *Environment) setupKubectl() error {
 	*/
 	sudoUser := os.Getenv("SUDO_USER")
 	if sudoUser != "" {
-		cmdLine := []string{"chown", "-R", fmt.Sprintf("%s:", sudoUser), kubeDirPath}
+		cmdLine := []string{"chown", "-R", fmt.Sprintf("%s:", sudoUser), path.Dir(e.kubeConfigUserPath)}
 		glog.V(5).Infof("%s", strings.Join(cmdLine, " "))
 		b, err := exec.Command(cmdLine[0], cmdLine[1:]...).CombinedOutput()
 		output = string(b)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -59,6 +59,7 @@ type Environment struct {
 
 	kubeletRootDir string
 
+	kubeConfigUserPath     string
 	kubeConfigAuthPath     string
 	kubeConfigInsecurePath string
 	etcdDataABSPath        string
@@ -152,6 +153,7 @@ func NewConfigSetup(givenRootPath string) (*Environment, error) {
 		networkABSPath:           path.Join(rootABSPath, defaultNetworkDirName),
 		templateVersion:          getMajorMinorVersion(config.ViperConfig.GetString("hyperkube-version")),
 
+		kubeConfigUserPath:     config.ViperConfig.GetString("kubeconfig-path"),
 		kubeConfigAuthPath:     path.Join(rootABSPath, defaultTemplates.ManifestConfig, "kubeconfig-auth.yaml"),
 		kubeConfigInsecurePath: path.Join(rootABSPath, defaultTemplates.ManifestConfig, "kubeconfig-insecure.yaml"),
 		etcdDataABSPath:        path.Join(rootABSPath, defaultEtcdDataDirName),
@@ -224,6 +226,12 @@ func NewConfigSetup(givenRootPath string) (*Environment, error) {
 	if err != nil {
 		glog.Errorf("Unexpected error: %v", err)
 		return nil, err
+	}
+
+	// kubeconfig
+	if e.kubeConfigUserPath == "" {
+		kubeDirPath := path.Join(getHome(), ".kube")
+		e.kubeConfigUserPath = path.Join(kubeDirPath, "config")
 	}
 
 	// Template for manifests

--- a/pkg/setup/systemd.go
+++ b/pkg/setup/systemd.go
@@ -139,7 +139,7 @@ func (e *Environment) linkSystemdUnit(unitOpt []*unit2.UnitOption, manifestUnitN
 		glog.Errorf("Fail to link systemd unit %s -> %s: %v", manifestUnitName, unitABSPath, err)
 		return err
 	}
-	glog.V(4).Infof("Successfully linked systemd unit %%s -> %s", manifestUnitName, unitABSPath)
+	glog.V(4).Infof("Successfully linked systemd unit %s -> %s", manifestUnitName, unitABSPath)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Introduce [sonobuoy](https://github.com/heptio/sonobuoy) in the CI pipeline

### Motivation

Use existing tools to validate the Kubernetes setup.

### Additional Notes

The `Quick` does not implement a lot of tests.

Along the way, I found convenient to add a `--kubeconfig-path` flag as an alternative to the behaviour around the `$SUDO_USER`