### PR TITLE
Remove the archive on extract failure

### DIFF
--- a/pkg/setup/binary.go
+++ b/pkg/setup/binary.go
@@ -101,7 +101,7 @@ func (d *depBinary) download() error {
 func (d *depBinary) removeArchive() error {
 	err := os.Remove(d.archivePath)
 	if err != nil {
-		glog.Errorf("Cannot remove the archive %s: %v", d.archivePath, err)
+		glog.Infof("Cannot remove the archive %s: %v", d.archivePath, err)
 		return err
 	}
 	glog.V(2).Infof("Removed %s", d.archivePath)

--- a/pkg/setup/binary.go
+++ b/pkg/setup/binary.go
@@ -97,3 +97,13 @@ func (d *depBinary) download() error {
 	}
 	return nil
 }
+
+func (d *depBinary) removeArchive() error {
+	err := os.Remove(d.archivePath)
+	if err != nil {
+		glog.Errorf("Cannot remove the archive %s: %v", d.archivePath, err)
+		return err
+	}
+	glog.V(2).Infof("Removed %s", d.archivePath)
+	return nil
+}

--- a/pkg/setup/binary_cni.go
+++ b/pkg/setup/binary_cni.go
@@ -20,6 +20,7 @@ func (e *Environment) extractCNI() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryCNI.archivePath, output, err)
+		e.binaryCNI.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryCNI.binaryABSPath)

--- a/pkg/setup/binary_cni.go
+++ b/pkg/setup/binary_cni.go
@@ -20,7 +20,7 @@ func (e *Environment) extractCNI() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryCNI.archivePath, output, err)
-		e.binaryCNI.removeArchive()
+		_ = e.binaryCNI.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryCNI.binaryABSPath)

--- a/pkg/setup/binary_etcd.go
+++ b/pkg/setup/binary_etcd.go
@@ -20,7 +20,7 @@ func (e *Environment) extractEtcd() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryEtcd.archivePath, output, err)
-		e.binaryEtcd.removeArchive()
+		_ = e.binaryEtcd.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryEtcd.binaryABSPath)

--- a/pkg/setup/binary_etcd.go
+++ b/pkg/setup/binary_etcd.go
@@ -20,6 +20,7 @@ func (e *Environment) extractEtcd() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryEtcd.archivePath, output, err)
+		e.binaryEtcd.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryEtcd.binaryABSPath)

--- a/pkg/setup/binary_hyperkube.go
+++ b/pkg/setup/binary_hyperkube.go
@@ -19,7 +19,7 @@ func (e *Environment) extractHyperkube() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryHyperkube.archivePath, output, err)
-		e.binaryHyperkube.removeArchive()
+		_ = e.binaryHyperkube.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryHyperkube.binaryABSPath)

--- a/pkg/setup/binary_hyperkube.go
+++ b/pkg/setup/binary_hyperkube.go
@@ -19,6 +19,7 @@ func (e *Environment) extractHyperkube() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot untar %s, %s: %v", e.binaryHyperkube.archivePath, output, err)
+		e.binaryHyperkube.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryHyperkube.binaryABSPath)

--- a/pkg/setup/binary_vault.go
+++ b/pkg/setup/binary_vault.go
@@ -19,7 +19,7 @@ func (e *Environment) extractVault() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot unzip %s, %s: %v", e.binaryVault.archivePath, output, err)
-		e.binaryVault.removeArchive()
+		_ = e.binaryVault.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryVault.binaryABSPath)

--- a/pkg/setup/binary_vault.go
+++ b/pkg/setup/binary_vault.go
@@ -19,6 +19,7 @@ func (e *Environment) extractVault() error {
 	output := string(b)
 	if err != nil {
 		glog.Errorf("Cannot unzip %s, %s: %v", e.binaryVault.archivePath, output, err)
+		e.binaryVault.removeArchive()
 		return err
 	}
 	_, err = os.Stat(e.binaryVault.binaryABSPath)


### PR DESCRIPTION
### What does this PR do?

During the setup/binaries stage, if the download is interrupted by the user, the file isn't completed.
When retrying to run the pupernetes commands, it continuously fail if you don't clean the binaries.

I propose to automatically removes the archive when it cannot extract the binary from it:
```text
sudo ./pupernetes d setup sandbox/ -c -binaries
W0626 20:59:04.344539    9005 clean.go:74] Cannot use kubectl: stat /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube: no such file or directory
I0626 20:59:04.349950    9005 systemd_action.go:123] Stopping p8s-etcd.service ...
E0626 20:59:04.351226    9005 systemd_action.go:74] Cannot execute systemd action on p8s-etcd.service: Unit p8s-etcd.service not loaded.
E0626 20:59:04.351600    9005 clean.go:134] Cannot stop systemd unit p8s-etcd.service: Unit p8s-etcd.service not loaded.
I0626 20:59:04.351644    9005 systemd_action.go:123] Stopping p8s-kubelet.service ...
E0626 20:59:04.352240    9005 systemd_action.go:74] Cannot execute systemd action on p8s-kubelet.service: Unit p8s-kubelet.service not loaded.
E0626 20:59:04.352257    9005 clean.go:134] Cannot stop systemd unit p8s-kubelet.service: Unit p8s-kubelet.service not loaded.
I0626 20:59:04.352266    9005 systemd_action.go:123] Stopping p8s-kube-apiserver.service ...
E0626 20:59:04.352615    9005 systemd_action.go:74] Cannot execute systemd action on p8s-kube-apiserver.service: Unit p8s-kube-apiserver.service not loaded.
E0626 20:59:04.352639    9005 clean.go:134] Cannot stop systemd unit p8s-kube-apiserver.service: Unit p8s-kube-apiserver.service not loaded.
I0626 20:59:04.354330    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/etcd-data
I0626 20:59:04.354508    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/source-templates
I0626 20:59:04.354541    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-static-pod
I0626 20:59:04.354569    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-api
I0626 20:59:04.354600    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-config
I0626 20:59:04.354626    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-systemd-unit
I0626 20:59:04.354657    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/secrets
I0626 20:59:04.354683    9005 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/net.d
I0626 20:59:04.354739    9005 clean.go:32] Removed /var/lib/p8s-kubelet
I0626 20:59:04.354769    9005 clean.go:164] Cleanup finished
I0626 20:59:04.379103    9005 hostname.go:59] Using hostname: "v1704"
I0626 20:59:04.446741    9005 binary.go:87] Archive already here: /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
I0626 20:59:04.446842    9005 binary_hyperkube.go:17] Extracting /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
E0626 20:59:04.956028    9005 binary_hyperkube.go:21] Cannot untar /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz, 
gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
: exit status 2, removing
I0626 20:59:04.958632    9005 binary.go:107] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
E0626 20:59:04.958684    9005 main.go:27] Exiting on error: 1
```

Then it's easier to re-run the command:
```text
sudo ./pupernetes d setup sandbox/ -c -binaries
W0626 20:59:08.215768    9037 clean.go:74] Cannot use kubectl: stat /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube: no such file or directory
I0626 20:59:08.221859    9037 systemd_action.go:123] Stopping p8s-etcd.service ...
E0626 20:59:08.222383    9037 systemd_action.go:74] Cannot execute systemd action on p8s-etcd.service: Unit p8s-etcd.service not loaded.
E0626 20:59:08.222614    9037 clean.go:134] Cannot stop systemd unit p8s-etcd.service: Unit p8s-etcd.service not loaded.
I0626 20:59:08.222625    9037 systemd_action.go:123] Stopping p8s-kubelet.service ...
E0626 20:59:08.223078    9037 systemd_action.go:74] Cannot execute systemd action on p8s-kubelet.service: Unit p8s-kubelet.service not loaded.
E0626 20:59:08.223101    9037 clean.go:134] Cannot stop systemd unit p8s-kubelet.service: Unit p8s-kubelet.service not loaded.
I0626 20:59:08.223114    9037 systemd_action.go:123] Stopping p8s-kube-apiserver.service ...
E0626 20:59:08.223742    9037 systemd_action.go:74] Cannot execute systemd action on p8s-kube-apiserver.service: Unit p8s-kube-apiserver.service not loaded.
E0626 20:59:08.223781    9037 clean.go:134] Cannot stop systemd unit p8s-kube-apiserver.service: Unit p8s-kube-apiserver.service not loaded.
I0626 20:59:08.226225    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/etcd-data
I0626 20:59:08.226480    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/source-templates
I0626 20:59:08.226533    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-static-pod
I0626 20:59:08.226581    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-api
I0626 20:59:08.226629    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-config
I0626 20:59:08.226677    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/manifest-systemd-unit
I0626 20:59:08.226725    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/secrets
I0626 20:59:08.226774    9037 clean.go:32] Removed /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/net.d
I0626 20:59:08.226836    9037 clean.go:32] Removed /var/lib/p8s-kubelet
I0626 20:59:08.226863    9037 clean.go:164] Cleanup finished
I0626 20:59:08.245307    9037 hostname.go:59] Using hostname: "v1704"
I0626 20:59:08.288817    9037 binary.go:52] Downloading the archive https://dl.k8s.io/v1.10.3/kubernetes-server-linux-amd64.tar.gz to /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
I0626 21:00:24.027496    9037 binary.go:80] Successfully downloaded https://dl.k8s.io/v1.10.3/kubernetes-server-linux-amd64.tar.gz to /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
I0626 21:00:24.027569    9037 binary_hyperkube.go:17] Extracting /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz
I0626 21:00:34.612591    9037 binary_hyperkube.go:29] Successfully untar /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin/hyperkube-v1.10.3.tar.gz: kubernetes/server/bin/hyperkube
I0626 21:00:34.857428    9037 binary_hyperkube.go:47] Generated links for hyperkube in /home/jb/go/src/github.com/DataDog/pupernetes/sandbox/bin
I0626 21:00:34.983864    9037 manifests.go:99] Using template collection of Kubernetes 1.10
I0626 21:00:37.352117    9037 setup.go:310] Setup ready /home/jb/go/src/github.com/DataDog/pupernetes/sandbox
```

### Motivation

Improve the interactive user experience.

### Additional Notes

This is a first step to maybe add a global retry to the binary setup.