### PR TITLE
Stop the systemd units in a reverse order

### DIFF
--- a/pkg/run/stop.go
+++ b/pkg/run/stop.go
@@ -240,7 +240,7 @@ func (r *Runtime) Stop(withError error) error {
 		}
 	}
 
-	for i := len(r.env.GetSystemdUnits()) - 1; i != -1; i-- {
+	for i := len(r.env.GetSystemdUnits()) - 1; i >= 0; i-- {
 		err = util.StopUnit(r.env.GetDBUSClient(), r.env.GetSystemdUnits()[i])
 		if err != nil {
 			errs = append(errs, err.Error())

--- a/pkg/run/stop.go
+++ b/pkg/run/stop.go
@@ -240,8 +240,8 @@ func (r *Runtime) Stop(withError error) error {
 		}
 	}
 
-	for _, u := range r.env.GetSystemdUnits() {
-		err = util.StopUnit(r.env.GetDBUSClient(), u)
+	for i := len(r.env.GetSystemdUnits()) - 1; i != -1; i-- {
+		err = util.StopUnit(r.env.GetDBUSClient(), r.env.GetSystemdUnits()[i])
 		if err != nil {
 			errs = append(errs, err.Error())
 		}

--- a/pkg/setup/clean.go
+++ b/pkg/setup/clean.go
@@ -127,12 +127,13 @@ func (e *Environment) Clean() error {
 		}
 		defer conn.Reload()
 		defer conn.Close()
-		for _, u := range e.systemdUnitNames {
+
+		for i := len(e.GetSystemdUnits()) - 1; i != -1; i-- {
+			u := e.GetSystemdUnits()[i]
 			toRemove = append(toRemove, UnitPath+u)
 			err = util.StopUnit(conn, u)
 			if err != nil {
-				glog.Errorf("Cannot stop systemd unit %s: %v", u, err)
-				// don't return
+				glog.Infof("Cannot stop systemd unit %s: %v", u, err)
 			}
 		}
 	}

--- a/pkg/setup/clean.go
+++ b/pkg/setup/clean.go
@@ -128,7 +128,7 @@ func (e *Environment) Clean() error {
 		defer conn.Reload()
 		defer conn.Close()
 
-		for i := len(e.GetSystemdUnits()) - 1; i != -1; i-- {
+		for i := len(e.GetSystemdUnits()) - 1; i >= 0; i-- {
 			u := e.GetSystemdUnits()[i]
 			toRemove = append(toRemove, UnitPath+u)
 			err = util.StopUnit(conn, u)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -169,8 +169,8 @@ func NewConfigSetup(givenRootPath string) (*Environment, error) {
 
 	e.systemdUnitNames = []string{
 		e.etcdUnitName,
-		e.kubeletUnitName,
 		e.kubeAPIServerUnitName,
+		e.kubeletUnitName,
 	}
 	// Kubernetes
 	e.binaryHyperkube = &exeBinary{


### PR DESCRIPTION
### What does this PR do?

The units are started in the following order:
* etcd
* kube-apiserver
* kubelet

It's better to stop them in a reverse order because when the kube-apiserver loose the access to the etcd, it increases the CPU usage.

I also changed the initial order to start the kube-apiserver before the kubelet.

### Motivation

This change is needed when using Kubelet TLS Bootstrap as the Kubelet needs the kube-apiserver.
To use the TLS Bootstrap, the controller-manager can't be containerised because it's required to issue the certificates.

