### PR TITLE
Add hyperkube 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ dist: trusty
 
 env:
   matrix:
+    - HYPERKUBE_VERSION=1.11.0
     - HYPERKUBE_VERSION=1.10.1
     - HYPERKUBE_VERSION=1.9.1
     - HYPERKUBE_VERSION=1.8.6


### PR DESCRIPTION
### What does this PR do?

Introduce the Kubernetes 1.11.0 release in the default travis pipeline matrix.
