### PR TITLE
Fix the re-apply system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,14 @@ jobs:
           name: sonobuoy
           command: ./.ci/sonobuoy.sh
 
+      - run:
+          name: reset
+          command: ./pupernetes reset default kube-system --apply
+
+      - run:
+          name: validation
+          command: ./.ci/pupernetes-validation.sh
+
 workflows:
   version: 2
   tests:

--- a/pkg/run/readiness.go
+++ b/pkg/run/readiness.go
@@ -15,10 +15,6 @@ import (
 )
 
 func (r *Runtime) applyManifests() error {
-	if r.state.IsKubectlApplied() {
-		glog.V(5).Infof("Kubectl is already applied")
-		return nil
-	}
 	glog.Infof("Calling kubectl apply -f %s ...", r.env.GetManifestsPathToApply())
 	b, err := exec.Command(r.env.GetHyperkubePath(), "kubectl", "--kubeconfig", r.env.GetKubeconfigInsecurePath(), "apply", "-f", r.env.GetManifestsPathToApply()).CombinedOutput()
 	output := string(b)
@@ -27,7 +23,6 @@ func (r *Runtime) applyManifests() error {
 		return err
 	}
 	glog.V(2).Infof("Successfully applied manifests:\n%s", output)
-	r.state.SetKubectlApplied()
 	return nil
 }
 

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -189,12 +189,15 @@ func (r *Runtime) Run() error {
 				continue
 			}
 			// kubectl apply -f manifests-api
-			err = r.applyManifests()
-			if err != nil {
-				// TODO do we trigger an exit at some point
-				// TODO because it's almost a deadlock if the user didn't set a short --timeoutTimer
-				glog.Errorf("Cannot apply manifests in %s", r.env.GetManifestsPathToApply())
-				continue
+			if !r.state.IsKubectlApplied() {
+				err = r.applyManifests()
+				if err != nil {
+					// TODO do we trigger an exit at some point
+					// TODO because it's almost a deadlock if the user didn't set a short --timeoutTimer
+					glog.Errorf("Cannot apply manifests in %s", r.env.GetManifestsPathToApply())
+					continue
+				}
+				r.state.SetKubectlApplied()
 			}
 			err = r.checkInClusterDNS()
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

After #73, I introduced a regression when using `pupernetes reset $ns --apply` or `SIGSTP`.

The `re-apply` feature doesn't work anymore.

To avoid this kind of regression I added a test in the CI.

### Additional Notes

This should be short released on `v0.6.1`.