### PR TITLE
Logging improvements on setup requirements

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,7 @@ func main() {
 	command, exitCode := cli.NewCommand()
 	err := command.Execute()
 	if err != nil {
-		os.Exit(1)
+		glog.Exitf("Error while running the command: %v", err)
 	}
 	if *exitCode != 0 {
 		glog.Errorf("Exiting on error: %d", *exitCode)

--- a/pkg/setup/requirements/requirements.go
+++ b/pkg/setup/requirements/requirements.go
@@ -49,7 +49,9 @@ func checkResources() error {
 // TODO configure this
 func CheckRequirements() error {
 	if os.Geteuid() != 0 {
-		return fmt.Errorf("must run as root")
+		err := fmt.Errorf("must run as root")
+		glog.Errorf("Requirement failure: %v", err)
+		return err
 	}
 	err := checkResources()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Fix a missing log in the setup stage.

### Motivation

When starting a setup without being root, the command fails without any log.

### Additional Notes

#### Before
```text
./pupernetes daemon run /opt/new-dir
I0704 19:00:37.405322   24527 clean.go:165] Cleanup finished
E0704 19:00:37.406233   24527 main.go:27] Exiting on error: 1
```

#### Now
```text
./pupernetes daemon run /opt/new-dir
I0704 19:00:37.405322   24527 clean.go:165] Cleanup finished
E0704 19:00:37.405496   24527 requirements.go:53] Requirement failure: must run as root
E0704 19:00:37.406233   24527 main.go:27] Exiting on error: 1
```