### PR TITLE
Improve circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ templates:
       SUDO_USER: "circleci"
 
 jobs:
-  make:
+  build:
     <<: *docker_job_template
     steps:
       - checkout
@@ -73,7 +73,7 @@ jobs:
       - checkout
       - run:
           name: make
-          command: make
+          command: make pupernetes-docker
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
@@ -128,7 +128,7 @@ jobs:
       - checkout
       - run:
           name: make
-          command: make
+          command: make pupernetes-docker
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
@@ -156,7 +156,7 @@ jobs:
       - checkout
       - run:
           name: make
-          command: make
+          command: make pupernetes-docker
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
@@ -172,7 +172,7 @@ jobs:
 
       - run:
           name: validation
-          command: ./.ci/pupernetes-validation.sh
+          command: make ci-validation
 
   sonobuoy:
     <<: *machine_job_template
@@ -180,7 +180,7 @@ jobs:
       - checkout
       - run:
           name: make
-          command: make
+          command: make pupernetes-docker
       - run:
           name: apt
           command: sudo apt-get update -q && sudo apt-get install -yq systemd
@@ -196,7 +196,7 @@ jobs:
 
       - run:
           name: sonobuoy
-          command: ./.ci/sonobuoy.sh
+          command: make ci-sonobuoy
 
       - run:
           name: reset
@@ -204,31 +204,32 @@ jobs:
 
       - run:
           name: validation
-          command: ./.ci/pupernetes-validation.sh
+          command: make ci-validation
+
 
 workflows:
   version: 2
-  tests:
+  pupernetes:
     jobs:
+      - build
       - tests
-
-  build:
-    jobs:
-      - make
-
-  verify:
-    jobs:
       - gofmt
       - docs
       - license
       - misc
-
-  daemon:
-    jobs:
-      - setup_fg
-      - run_fg
-      - run_systemd
-
-  sonobuoy:
-    jobs:
-      - sonobuoy
+      - setup_fg:
+          requires:
+            - build
+            - tests
+      - run_fg:
+          requires:
+            - build
+            - tests
+      - run_systemd:
+          requires:
+            - build
+            - tests
+      - sonobuoy:
+         requires:
+           - build
+           - tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
 
 script:
   - sudo ./pupernetes daemon run sandbox/ -v 4 --job-type systemd --bind-address 0.0.0.0:8989 --hyperkube-version $HYPERKUBE_VERSION --kubeconfig-path $HOME/.kube/config
-  - ./.ci/pupernetes-validation.sh
+  - make ci-validation
 
 # debug commands
 after_failure:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ goget:
 	@which ineffassign || go get github.com/gordonklaus/ineffassign
 	@which golint || go get golang.org/x/lint/golint
 	@which misspell || go get github.com/client9/misspell/cmd/misspell
+	@which wwhrd || go get github.com/frapposelli/wwhrd
 
 # Private targets
 PKG=.cmd .pkg .docs
@@ -47,7 +48,7 @@ verify-gofmt:
 verify-docs:
 	./scripts/verify/docs.sh
 
-verify-license:
+verify-license: goget
 	./scripts/verify/license.sh
 
 verify: verify-misc verify-gofmt verify-docs verify-license
@@ -55,8 +56,8 @@ verify: verify-misc verify-gofmt verify-docs verify-license
 sha512sum: pupernetes
 	$@ ./$^ > $^.$@
 
-pupernetes-docker: clean
-	docker run --rm --net=host -v $(PWD):/go/src/github.com/DataDog/pupernetes -w /go/src/github.com/DataDog/pupernetes golang:1.10 make sha512sum
+pupernetes-docker:
+	docker run --rm --net=host -v $(PWD):/go/src/github.com/DataDog/pupernetes -w /go/src/github.com/DataDog/pupernetes golang:1.10 make
 
 ci-validation:
 	./.ci/pupernetes-validation.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,10 @@ Compile statically the binary and generate the sha512sum.
 CGO_ENABLED=0 make sha512sum
 
 # or using docker
-docker run --rm -v "$GOPATH":/go -w /go/src/github.com/DataDog/pupernetes golang:1.10 make sha512sum
+docker run --rm -v "$GOPATH":/go -w /go/src/github.com/DataDog/pupernetes golang:1.10 make re sha512sum
+
+# equivalent to
+make pupernetes-docker
 ```
 
 Check the shared object dependencies:

--- a/scripts/update/license.sh
+++ b/scripts/update/license.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-set -ex
+set -exo pipefail
 
 export LC_ALL=C
-
-go get github.com/frapposelli/wwhrd
 
 cd $(dirname $0)/../..
 


### PR DESCRIPTION
### What does this PR do?

Improve the circle CI workflow as suggested in #86 

### Motivation

Don't start machine executor if the build failed.
Use golang 1.10 everywhere: build pupernetes from `docker://golang:1.10`.

### Additional Notes

To attempt to cache the pupernetes directory, I tried to use:
* persist_to_workspace
* attach_workspace

But I get the following error in the machine executor:
```text
Downloading workspace layers
  workflows/workspaces/971cef4a-2eae-441e-a45a-2aa4275d8612/0/5611dc91-3ef1-443b-9c59-922beca7d436/0/108.tar.gz - 21 MB
Applying workspace layers
  5611dc91-3ef1-443b-9c59-922beca7d436

Error applying workspace layer for job 5611dc91-3ef1-443b-9c59-922beca7d436: Error extracting tarball /tmp/workspace-layer-5611dc91-3ef1-443b-9c59-922beca7d436241049481: exit status 2
```
See:
* https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace