### PR TITLE
Introduce skip probe

### DIFF
--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -146,7 +146,12 @@ func NewCommand() (*cobra.Command, *int) {
 			if config.ViperConfig.GetBool("dns-check") {
 				dnsQuery = config.ViperConfig.GetStringSlice("dns-queries")
 			}
-			r, err := run.NewRunner(env, config.ViperConfig.GetDuration("run-timeout"), config.ViperConfig.GetDuration("gc"), dnsQuery)
+			r, err := run.NewRunner(env, &run.Config{
+				RunTimeout:           config.ViperConfig.GetDuration("run-timeout"),
+				WaitKubeletGC:        config.ViperConfig.GetDuration("gc"),
+				DNSQueryForReadiness: dnsQuery,
+				SkipProbe:            config.ViperConfig.GetBool("skip-probe"),
+			})
 			if err != nil {
 				exitCode = 2
 				return
@@ -334,6 +339,9 @@ func NewCommand() (*cobra.Command, *int) {
 
 	runCommand.PersistentFlags().Bool("dns-check", config.ViperConfig.GetBool("dns-check"), "needed dns queries to notify readiness")
 	config.ViperConfig.BindPFlag("dns-check", runCommand.PersistentFlags().Lookup("dns-check"))
+
+	runCommand.PersistentFlags().Bool("skip-probe", config.ViperConfig.GetBool("skip-probe"), "skip probing systemd units and kubelet healthz")
+	config.ViperConfig.BindPFlag("skip-probe", runCommand.PersistentFlags().Lookup("skip-probe"))
 
 	// Reset
 	rootCommand.AddCommand(resetCommand)

--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -147,10 +147,10 @@ func NewCommand() (*cobra.Command, *int) {
 				dnsQuery = config.ViperConfig.GetStringSlice("dns-queries")
 			}
 			r, err := run.NewRunner(env, &run.Config{
-				RunTimeout:           config.ViperConfig.GetDuration("run-timeout"),
-				WaitKubeletGC:        config.ViperConfig.GetDuration("gc"),
-				DNSQueryForReadiness: dnsQuery,
-				SkipProbe:            config.ViperConfig.GetBool("skip-probe"),
+				RunTimeout:          config.ViperConfig.GetDuration("run-timeout"),
+				KubeletGCTimeout:    config.ViperConfig.GetDuration("gc"),
+				ReadinessDNSQueries: dnsQuery,
+				SkipProbes:          config.ViperConfig.GetBool("skip-probes"),
 			})
 			if err != nil {
 				exitCode = 2
@@ -340,8 +340,8 @@ func NewCommand() (*cobra.Command, *int) {
 	runCommand.PersistentFlags().Bool("dns-check", config.ViperConfig.GetBool("dns-check"), "needed dns queries to notify readiness")
 	config.ViperConfig.BindPFlag("dns-check", runCommand.PersistentFlags().Lookup("dns-check"))
 
-	runCommand.PersistentFlags().Bool("skip-probe", config.ViperConfig.GetBool("skip-probe"), "skip probing systemd units and kubelet healthz")
-	config.ViperConfig.BindPFlag("skip-probe", runCommand.PersistentFlags().Lookup("skip-probe"))
+	runCommand.PersistentFlags().Bool("skip-probes", config.ViperConfig.GetBool("skip-probes"), "skip probing systemd units and kubelet healthz")
+	config.ViperConfig.BindPFlag("skip-probes", runCommand.PersistentFlags().Lookup("skip-probes"))
 
 	// Reset
 	rootCommand.AddCommand(resetCommand)

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -50,6 +50,7 @@ pupernetes daemon run /opt/state/ --dns-check --dns-queries quay.io.,coredns.kub
   -h, --help                      help for run
       --job-type string           type of job: fg or systemd (default "fg")
       --run-timeout duration      maximum time to run pupernetes for until self shutdown (default 7h0m0s)
+      --skip-probe                skip probing systemd units and kubelet healthz
       --systemd-job-name string   unit name used when running as systemd service (default "pupernetes")
 ```
 

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -50,7 +50,7 @@ pupernetes daemon run /opt/state/ --dns-check --dns-queries quay.io.,coredns.kub
   -h, --help                      help for run
       --job-type string           type of job: fg or systemd (default "fg")
       --run-timeout duration      maximum time to run pupernetes for until self shutdown (default 7h0m0s)
-      --skip-probe                skip probing systemd units and kubelet healthz
+      --skip-probes               skip probing systemd units and kubelet healthz
       --systemd-job-name string   unit name used when running as systemd service (default "pupernetes")
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,7 @@ func init() {
 	ViperConfig.SetDefault("clean", "etcd,kubelet,mounts,iptables")
 	ViperConfig.SetDefault("drain", "all")
 	ViperConfig.SetDefault("run-timeout", time.Hour*7)
-	ViperConfig.SetDefault("skip-probe", false)
+	ViperConfig.SetDefault("skip-probes", false)
 	ViperConfig.SetDefault("gc", time.Second*60)
 
 	// The supported job-type are "fg" and "systemd"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ func init() {
 	ViperConfig.SetDefault("clean", "etcd,kubelet,mounts,iptables")
 	ViperConfig.SetDefault("drain", "all")
 	ViperConfig.SetDefault("run-timeout", time.Hour*7)
+	ViperConfig.SetDefault("skip-probe", false)
 	ViperConfig.SetDefault("gc", time.Second*60)
 
 	// The supported job-type are "fg" and "systemd"

--- a/pkg/run/readiness.go
+++ b/pkg/run/readiness.go
@@ -27,12 +27,12 @@ func (r *Runtime) applyManifests() error {
 }
 
 func (r *Runtime) checkInClusterDNS() error {
-	if r.dnsQueriesForReadiness == nil {
+	if r.conf.DNSQueryForReadiness == nil {
 		glog.V(2).Infof("No dns query supplied for readiness condition, skipping")
 		return nil
 	}
 	c := dns.Client{Timeout: time.Millisecond * 500}
-	for _, query := range r.dnsQueriesForReadiness {
+	for _, query := range r.conf.DNSQueryForReadiness {
 		if !strings.HasSuffix(query, ".") {
 			// dns: domain must be fully qualified
 			query = query + "."

--- a/pkg/run/readiness.go
+++ b/pkg/run/readiness.go
@@ -27,12 +27,12 @@ func (r *Runtime) applyManifests() error {
 }
 
 func (r *Runtime) checkInClusterDNS() error {
-	if r.conf.DNSQueryForReadiness == nil {
+	if r.conf.ReadinessDNSQueries == nil {
 		glog.V(2).Infof("No dns query supplied for readiness condition, skipping")
 		return nil
 	}
 	c := dns.Client{Timeout: time.Millisecond * 500}
-	for _, query := range r.conf.DNSQueryForReadiness {
+	for _, query := range r.conf.ReadinessDNSQueries {
 		if !strings.HasSuffix(query, ".") {
 			// dns: domain must be fully qualified
 			query = query + "."

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -34,14 +34,14 @@ type Config struct {
 	// RunTimeout is the total time to run
 	RunTimeout time.Duration
 
-	// WaitKubeletGC is the duration period to wait until the kubelet is garbage collected
-	WaitKubeletGC time.Duration
+	// KubeletGCTimeout is the duration period to wait until the kubelet is garbage collected
+	KubeletGCTimeout time.Duration
 
-	// DNSQueryForReadiness are the dns query to execute to ack the readiness
-	DNSQueryForReadiness []string
+	// ReadinessDNSQueries are the dns query to execute to ack the readiness
+	ReadinessDNSQueries []string
 
-	// SkipProbe allows to discard any check on the environment to keep running
-	SkipProbe bool
+	// SkipProbes allows to discard any check on the environment to keep running
+	SkipProbes bool
 }
 
 // Runtime is the main state to execute a managed pupernetes Run
@@ -139,7 +139,7 @@ func (r *Runtime) Run() error {
 
 		case <-probeTick.C:
 			_, err := r.probeUnitStatuses()
-			if err != nil && !r.conf.SkipProbe {
+			if err != nil && !r.conf.SkipProbes {
 				r.SigChan <- syscall.SIGTERM
 				continue
 			}
@@ -148,7 +148,7 @@ func (r *Runtime) Run() error {
 				continue
 			}
 			failures := r.state.GetKubeletProbeFail()
-			if failures >= appProbeThreshold && !r.conf.SkipProbe {
+			if failures >= appProbeThreshold && !r.conf.SkipProbes {
 				glog.Warningf("Probing failed, stopping ...")
 				// display some helpers to investigate:
 				glog.Infof("Investigate the kubelet logs with: journalctl -u %skubelet.service -o cat -e --no-pager", r.env.GetSystemdUnitPrefix())

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -29,19 +29,33 @@ const (
 	appProbeThreshold = 10
 )
 
+// Config for the Runtime
+type Config struct {
+	// RunTimeout is the total time to run
+	RunTimeout time.Duration
+
+	// WaitKubeletGC is the duration period to wait until the kubelet is garbage collected
+	WaitKubeletGC time.Duration
+
+	// DNSQueryForReadiness are the dns query to execute to ack the readiness
+	DNSQueryForReadiness []string
+
+	// SkipProbe allows to discard any check on the environment to keep running
+	SkipProbe bool
+}
+
 // Runtime is the main state to execute a managed pupernetes Run
 type Runtime struct {
 	env *setup.Environment
 
+	conf *Config
+
 	api *http.Server
 
-	SigChan                chan os.Signal
-	httpClient             *http.Client
-	state                  *state.State
-	runTimeout             time.Duration
-	dnsQueriesForReadiness []string
-	waitKubeletGC          time.Duration
-	kubeDeleteOption       *v1.DeleteOptions
+	SigChan          chan os.Signal
+	httpClient       *http.Client
+	state            *state.State
+	kubeDeleteOption *v1.DeleteOptions
 
 	runTimestamp       time.Time
 	journalTailerMutex sync.RWMutex
@@ -51,7 +65,7 @@ type Runtime struct {
 }
 
 // NewRunner instantiate a new Runtimer with the given Environment
-func NewRunner(env *setup.Environment, runTimeout, waitKubeletGC time.Duration, dnsQueryForReadiness []string) (*Runtime, error) {
+func NewRunner(env *setup.Environment, conf *Config) (*Runtime, error) {
 	var zero int64
 
 	s, err := state.NewState()
@@ -67,9 +81,7 @@ func NewRunner(env *setup.Environment, runTimeout, waitKubeletGC time.Duration, 
 		httpClient: &http.Client{
 			Timeout: time.Millisecond * 500,
 		},
-		runTimeout:             runTimeout,
-		dnsQueriesForReadiness: dnsQueryForReadiness,
-		waitKubeletGC:          waitKubeletGC,
+		conf: conf,
 		kubeDeleteOption: &v1.DeleteOptions{
 			GracePeriodSeconds: &zero,
 		},
@@ -88,8 +100,8 @@ func (r *Runtime) Run() error {
 
 	defer close(r.ApplyChan)
 
-	glog.Infof("Timeout for this current run is %s", r.runTimeout.String())
-	timeoutTimer := time.NewTimer(r.runTimeout)
+	glog.Infof("Timeout for this current run is %s", r.conf.RunTimeout.String())
+	timeoutTimer := time.NewTimer(r.conf.RunTimeout)
 	defer timeoutTimer.Stop()
 
 	go r.api.ListenAndServe()
@@ -122,12 +134,12 @@ func (r *Runtime) Run() error {
 			return r.Stop(nil)
 
 		case <-timeoutTimer.C:
-			glog.Warningf("Timeout %s reached, stopping ...", r.runTimeout.String())
-			return r.Stop(fmt.Errorf("timeout reached during run phase: %s", r.runTimeout.String()))
+			glog.Warningf("Timeout %s reached, stopping ...", r.conf.RunTimeout.String())
+			return r.Stop(fmt.Errorf("timeout reached during run phase: %s", r.conf.RunTimeout.String()))
 
 		case <-probeTick.C:
 			_, err := r.probeUnitStatuses()
-			if err != nil {
+			if err != nil && !r.conf.SkipProbe {
 				r.SigChan <- syscall.SIGTERM
 				continue
 			}
@@ -136,7 +148,7 @@ func (r *Runtime) Run() error {
 				continue
 			}
 			failures := r.state.GetKubeletProbeFail()
-			if failures >= appProbeThreshold {
+			if failures >= appProbeThreshold && !r.conf.SkipProbe {
 				glog.Warningf("Probing failed, stopping ...")
 				// display some helpers to investigate:
 				glog.Infof("Investigate the kubelet logs with: journalctl -u %skubelet.service -o cat -e --no-pager", r.env.GetSystemdUnitPrefix())

--- a/pkg/run/stop.go
+++ b/pkg/run/stop.go
@@ -111,7 +111,7 @@ func (r *Runtime) drainingPods() error {
 	stateTicker := time.NewTicker(3 * time.Second)
 	defer stateTicker.Stop()
 
-	timeoutDelay := r.conf.WaitKubeletGC
+	timeoutDelay := r.conf.KubeletGCTimeout
 	if !r.isAPIServerHookDone() {
 		timeoutDelay = timeoutDelay / 3
 		glog.Warningf("APIserver hooks aren't deployed, RBAC-less? Lowering the timeout to %s for static pods polling", timeoutDelay.String())

--- a/pkg/run/stop.go
+++ b/pkg/run/stop.go
@@ -111,7 +111,7 @@ func (r *Runtime) drainingPods() error {
 	stateTicker := time.NewTicker(3 * time.Second)
 	defer stateTicker.Stop()
 
-	timeoutDelay := r.waitKubeletGC
+	timeoutDelay := r.conf.WaitKubeletGC
 	if !r.isAPIServerHookDone() {
 		timeoutDelay = timeoutDelay / 3
 		glog.Warningf("APIserver hooks aren't deployed, RBAC-less? Lowering the timeout to %s for static pods polling", timeoutDelay.String())


### PR DESCRIPTION
### What does this PR do?

Skip probe allows to discard any failure of the environment.

### Motivation

This is very useful while iterating on kubernetes components (configuration or master dev).

### Additional Notes

I moved all the parameters to a dedicated config structure.

The name of the flag could also be something like `ignore-probe`