### PR TITLE
Remove default timeout

### DIFF
--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -49,7 +49,7 @@ pupernetes daemon run /opt/state/ --dns-check --dns-queries quay.io.,coredns.kub
       --gc duration               grace period for the kubelet GC trigger when draining run, no-op if not draining (default 1m0s)
   -h, --help                      help for run
       --job-type string           type of job: fg or systemd (default "fg")
-      --run-timeout duration      maximum time to run pupernetes for until self shutdown (default 7h0m0s)
+      --run-timeout duration      maximum time to run pupernetes for until self shutdown
       --skip-probes               skip probing systemd units and kubelet healthz
       --systemd-job-name string   unit name used when running as systemd service (default "pupernetes")
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,8 +6,9 @@
 package config
 
 import (
-	"github.com/spf13/viper"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 // ViperConfig is a global variable for the viper configuration
@@ -46,7 +47,6 @@ func init() {
 
 	ViperConfig.SetDefault("clean", "etcd,kubelet,logs,mounts,iptables")
 	ViperConfig.SetDefault("drain", "all")
-	ViperConfig.SetDefault("run-timeout", time.Hour*7)
 	ViperConfig.SetDefault("skip-probes", false)
 	ViperConfig.SetDefault("gc", time.Second*60)
 

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -100,7 +100,9 @@ func (r *Runtime) Run() error {
 
 	defer close(r.ApplyChan)
 
-	glog.Infof("Timeout for this current run is %s", r.conf.RunTimeout.String())
+	if r.conf.RunTimeout > 0 {
+		glog.Infof("Timeout for this current run is %s", r.conf.RunTimeout.String())
+	}
 	timeoutTimer := time.NewTimer(r.conf.RunTimeout)
 	defer timeoutTimer.Stop()
 
@@ -134,8 +136,10 @@ func (r *Runtime) Run() error {
 			return r.Stop(nil)
 
 		case <-timeoutTimer.C:
-			glog.Warningf("Timeout %s reached, stopping ...", r.conf.RunTimeout.String())
-			return r.Stop(fmt.Errorf("timeout reached during run phase: %s", r.conf.RunTimeout.String()))
+			if r.conf.RunTimeout > 0 {
+				glog.Warningf("Timeout %s reached, stopping ...", r.conf.RunTimeout.String())
+				return r.Stop(fmt.Errorf("timeout reached during run phase: %s", r.conf.RunTimeout.String()))
+			}
 
 		case <-probeTick.C:
 			if r.conf.SkipProbes {


### PR DESCRIPTION
### What does this PR do?

Remove the default (7 hours) timeout

### Motivation

We already have to set a shorter timeout when using the CI and the default timeout can be annoying in dev env where you could you lose some configuration.
