### PR TITLE
Remove useless stage in audit logs

### DIFF
--- a/pkg/setup/templates/1.10.go
+++ b/pkg/setup/templates/1.10.go
@@ -265,6 +265,8 @@ apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
 - level: Metadata
+  omitStages:
+    - RequestReceived
   resources:
   - group: ""
     resources: ["*"]

--- a/pkg/setup/templates/1.11.go
+++ b/pkg/setup/templates/1.11.go
@@ -264,6 +264,8 @@ apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
 - level: Metadata
+  omitStages:
+    - RequestReceived
   resources:
   - group: ""
     resources: ["*"]

--- a/pkg/setup/templates/1.8.go
+++ b/pkg/setup/templates/1.8.go
@@ -166,6 +166,8 @@ apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
 - level: Metadata
+  omitStages:
+    - RequestReceived
   resources:
   - group: ""
     resources: ["*"]

--- a/pkg/setup/templates/1.9.go
+++ b/pkg/setup/templates/1.9.go
@@ -265,6 +265,8 @@ apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
 - level: Metadata
+  omitStages:
+    - RequestReceived
   resources:
   - group: ""
     resources: ["*"]


### PR DESCRIPTION
### What does this PR do?

Remove useless stage in audit logs

### Motivation

Less apiserver audit logs, less cpu and disk access 

