### PR TITLE
Extend the audit logs to everything

### DIFF
--- a/pkg/setup/templates/1.10.go
+++ b/pkg/setup/templates/1.10.go
@@ -264,12 +264,19 @@ users:
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
-- level: Metadata
-  omitStages:
-    - RequestReceived
-  resources:
-  - group: ""
-    resources: ["*"]
+  - level: Request
+    verbs:
+      - create
+    omitStages:
+      - RequestReceived
+    resources:
+    - group: ""
+      resources:
+        - events
+
+  - level: Metadata
+    omitStages:
+      - RequestReceived
 `),
 		},
 		{

--- a/pkg/setup/templates/1.11.go
+++ b/pkg/setup/templates/1.11.go
@@ -263,12 +263,19 @@ users:
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
-- level: Metadata
-  omitStages:
-    - RequestReceived
-  resources:
-  - group: ""
-    resources: ["*"]
+  - level: Request
+    verbs:
+      - create
+    omitStages:
+      - RequestReceived
+    resources:
+    - group: ""
+      resources:
+        - events
+
+  - level: Metadata
+    omitStages:
+      - RequestReceived
 `),
 		},
 		{

--- a/pkg/setup/templates/1.8.go
+++ b/pkg/setup/templates/1.8.go
@@ -165,12 +165,19 @@ users:
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
-- level: Metadata
-  omitStages:
-    - RequestReceived
-  resources:
-  - group: ""
-    resources: ["*"]
+  - level: Request
+    verbs:
+      - create
+    omitStages:
+      - RequestReceived
+    resources:
+    - group: ""
+      resources:
+        - events
+
+  - level: Metadata
+    omitStages:
+      - RequestReceived
 `),
 		},
 		{

--- a/pkg/setup/templates/1.9.go
+++ b/pkg/setup/templates/1.9.go
@@ -264,12 +264,19 @@ users:
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
-- level: Metadata
-  omitStages:
-    - RequestReceived
-  resources:
-  - group: ""
-    resources: ["*"]
+  - level: Request
+    verbs:
+      - create
+    omitStages:
+      - RequestReceived
+    resources:
+    - group: ""
+      resources:
+        - events
+
+  - level: Metadata
+    omitStages:
+      - RequestReceived
 `),
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

The previous configuration only logs the core/v1 calls.

By removing the resource, it logs everything.

I also added the content of the events when they are created.