### PR TITLE
versions: upgrade hyperkube, etcd and containerd

### DIFF
--- a/docs/pupernetes_daemon.md
+++ b/docs/pupernetes_daemon.md
@@ -13,9 +13,9 @@ Use this command to clean setup and run a Kubernetes local environment
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
-      --etcd-version string                  etcd version (default "3.1.11")
+      --etcd-version string                  etcd version (default "3.1.19")
   -h, --help                                 help for daemon
-      --hyperkube-version string             hyperkube version (default "1.10.3")
+      --hyperkube-version string             hyperkube version (default "1.10.7")
   -k, --keep string                          clean everything but the given options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none, this flag overrides any clean options
       --kubeconfig-path string               path to the kubeconfig file
       --kubectl-link string                  path to create a kubectl link

--- a/docs/pupernetes_daemon_clean.md
+++ b/docs/pupernetes_daemon_clean.md
@@ -38,8 +38,8 @@ pupernetes daemon clean /opt/state/ -c etcd,network,secrets
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
-      --etcd-version string                  etcd version (default "3.1.11")
-      --hyperkube-version string             hyperkube version (default "1.10.3")
+      --etcd-version string                  etcd version (default "3.1.19")
+      --hyperkube-version string             hyperkube version (default "1.10.7")
   -k, --keep string                          clean everything but the given options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none, this flag overrides any clean options
       --kubeconfig-path string               path to the kubeconfig file
       --kubectl-link string                  path to create a kubectl link

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -61,8 +61,8 @@ pupernetes daemon run /opt/state/ --dns-check --dns-queries quay.io.,coredns.kub
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
-      --etcd-version string                  etcd version (default "3.1.11")
-      --hyperkube-version string             hyperkube version (default "1.10.3")
+      --etcd-version string                  etcd version (default "3.1.19")
+      --hyperkube-version string             hyperkube version (default "1.10.7")
   -k, --keep string                          clean everything but the given options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none, this flag overrides any clean options
       --kubeconfig-path string               path to the kubeconfig file
       --kubectl-link string                  path to create a kubectl link

--- a/docs/pupernetes_daemon_setup.md
+++ b/docs/pupernetes_daemon_setup.md
@@ -29,8 +29,8 @@ pupernetes daemon setup state/
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
-      --etcd-version string                  etcd version (default "3.1.11")
-      --hyperkube-version string             hyperkube version (default "1.10.3")
+      --etcd-version string                  etcd version (default "3.1.19")
+      --hyperkube-version string             hyperkube version (default "1.10.7")
   -k, --keep string                          clean everything but the given options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none, this flag overrides any clean options
       --kubeconfig-path string               path to the kubeconfig file
       --kubectl-link string                  path to create a kubectl link

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,11 +32,11 @@ const (
 )
 
 func init() {
-	ViperConfig.SetDefault("hyperkube-version", "1.10.3")
+	ViperConfig.SetDefault("hyperkube-version", "1.10.7")
 	ViperConfig.SetDefault("vault-version", "0.9.5")
-	ViperConfig.SetDefault("etcd-version", "3.1.11")
+	ViperConfig.SetDefault("etcd-version", "3.1.19")
 	ViperConfig.SetDefault("cni-version", "0.7.0")
-	ViperConfig.SetDefault("containerd-version", "1.1.0")
+	ViperConfig.SetDefault("containerd-version", "1.1.3")
 	ViperConfig.SetDefault("runc-version", "1.0.0-rc5")
 
 	ViperConfig.SetDefault("container-runtime", "docker")

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -218,7 +218,7 @@ func NewConfigSetup(givenRootPath string) (*Environment, error) {
 		depBinary: depBinary{
 			archivePath:     path.Join(e.binABSPath, fmt.Sprintf("etcd-v%s.tar.gz", config.ViperConfig.GetString("etcd-version"))),
 			binaryABSPath:   path.Join(e.binABSPath, "etcd"),
-			archiveURL:      fmt.Sprintf("https://github.com/coreos/etcd/releases/download/v%s/etcd-v%s-linux-amd64.tar.gz", config.ViperConfig.GetString("etcd-version"), config.ViperConfig.GetString("etcd-version")),
+			archiveURL:      fmt.Sprintf("https://github.com/etcd-io/etcd/releases/download/v%s/etcd-v%s-linux-amd64.tar.gz", config.ViperConfig.GetString("etcd-version"), config.ViperConfig.GetString("etcd-version")),
 			version:         config.ViperConfig.GetString("etcd-version"),
 			downloadTimeout: e.downloadTimeout,
 		},


### PR DESCRIPTION
### What does this PR do?

I upgraded the current versions of etcd, containerd and hyperkube.


### Additional Notes

coreos moved etcd to `etcd-io/etcd`