### PR TITLE
containerd: can choose the version over the command line

### DIFF
--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -278,6 +278,9 @@ func NewCommand() (*cobra.Command, *int) {
 	// daemon command
 	rootCommand.AddCommand(daemonCommand)
 
+	daemonCommand.PersistentFlags().String("containerd-version", config.ViperConfig.GetString("containerd-version"), "containerd version")
+	config.ViperConfig.BindPFlag("containerd-version", daemonCommand.PersistentFlags().Lookup("containerd-version"))
+
 	daemonCommand.PersistentFlags().String("hyperkube-version", config.ViperConfig.GetString("hyperkube-version"), "hyperkube version")
 	config.ViperConfig.BindPFlag("hyperkube-version", daemonCommand.PersistentFlags().Lookup("hyperkube-version"))
 

--- a/docs/pupernetes_daemon.md
+++ b/docs/pupernetes_daemon.md
@@ -12,6 +12,7 @@ Use this command to clean setup and run a Kubernetes local environment
   -c, --clean string                         clean options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,logs,mounts,iptables")
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
+      --containerd-version string            containerd version (default "1.1.3")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
       --etcd-version string                  etcd version (default "3.1.19")
   -h, --help                                 help for daemon

--- a/docs/pupernetes_daemon_clean.md
+++ b/docs/pupernetes_daemon_clean.md
@@ -37,6 +37,7 @@ pupernetes daemon clean /opt/state/ -c etcd,network,secrets
   -c, --clean string                         clean options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,logs,mounts,iptables")
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
+      --containerd-version string            containerd version (default "1.1.3")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
       --etcd-version string                  etcd version (default "3.1.19")
       --hyperkube-version string             hyperkube version (default "1.10.7")

--- a/docs/pupernetes_daemon_run.md
+++ b/docs/pupernetes_daemon_run.md
@@ -60,6 +60,7 @@ pupernetes daemon run /opt/state/ --dns-check --dns-queries quay.io.,coredns.kub
   -c, --clean string                         clean options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,logs,mounts,iptables")
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
+      --containerd-version string            containerd version (default "1.1.3")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
       --etcd-version string                  etcd version (default "3.1.19")
       --hyperkube-version string             hyperkube version (default "1.10.7")

--- a/docs/pupernetes_daemon_setup.md
+++ b/docs/pupernetes_daemon_setup.md
@@ -28,6 +28,7 @@ pupernetes daemon setup state/
   -c, --clean string                         clean options before setup: binaries,etcd,iptables,kubectl,kubelet,logs,manifests,mounts,network,secrets,systemd,all,none (default "etcd,kubelet,logs,mounts,iptables")
       --cni-version string                   container network interface (cni) version (default "0.7.0")
       --container-runtime string             container runtime interface to use (experimental: "containerd") (default "docker")
+      --containerd-version string            containerd version (default "1.1.3")
       --download-timeout string              timeout for each downloaded archive (default "30m0s")
       --etcd-version string                  etcd version (default "3.1.19")
       --hyperkube-version string             hyperkube version (default "1.10.7")


### PR DESCRIPTION
### What does this PR do?

The configuration already existed but wasn't exposed over the command line.
