### PR TITLE
makefile: set the constrain to go 1.10+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pupernetes: go-constraint
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) $(CC) build $(CFLAGS) $(VERSION_FLAGS) -o $@ cmd/main.go
 
 go-constraint:
-	go version | grep "go version go1.10"
+	go version | grep -E "go version go1.1[[:digit:]]"
 
 clean:
 	$(RM) pupernetes pupernetes.sha512sum


### PR DESCRIPTION
### What does this PR do?

Allows to build with go version 1.10+

