### PR TITLE
node: support shared PID

### DIFF
--- a/pkg/setup/templates/1.10.go
+++ b/pkg/setup/templates/1.10.go
@@ -45,6 +45,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),
@@ -113,6 +114,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.11.go
+++ b/pkg/setup/templates/1.11.go
@@ -45,6 +45,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),
@@ -112,6 +113,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.12.go
+++ b/pkg/setup/templates/1.12.go
@@ -44,6 +44,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),
@@ -111,6 +112,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--feature-gates=PodShareProcessNamespace=true \
 
 Restart=no
 `),


### PR DESCRIPTION
### What does this PR do?

This PR adds the support of the shared process namespace.
It allows to send signals from a container/task in an another one, as long they're in the same Pod.

### Motivation

This is needed to create a certificate renew story.

### Additional Notes

This is available at the pod's spec level.
