### PR TITLE
Fix systemd unit files

### DIFF
--- a/pkg/setup/templates/1.10.go
+++ b/pkg/setup/templates/1.10.go
@@ -45,7 +45,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -114,7 +114,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -139,7 +139,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.11.go
+++ b/pkg/setup/templates/1.11.go
@@ -45,7 +45,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -113,7 +113,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -138,7 +138,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.12.go
+++ b/pkg/setup/templates/1.12.go
@@ -44,7 +44,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
 	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -112,7 +112,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
 	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
-	--feature-gates=PodShareProcessNamespace=true \
+	--feature-gates=PodShareProcessNamespace=true
 
 Restart=no
 `),
@@ -137,7 +137,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.13.go
+++ b/pkg/setup/templates/1.13.go
@@ -43,7 +43,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--cni-bin-dir={{.RootABSPath}}/bin \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
-	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}}
 
 Restart=no
 `),
@@ -110,7 +110,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--audit-policy-file={{.RootABSPath}}/manifest-config/audit.yaml \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
-	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml
 
 Restart=no
 `),
@@ -135,7 +135,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.14.go
+++ b/pkg/setup/templates/1.14.go
@@ -43,7 +43,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--cni-bin-dir={{.RootABSPath}}/bin \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
-	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}}
 
 Restart=no
 `),
@@ -110,7 +110,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--audit-policy-file={{.RootABSPath}}/manifest-config/audit.yaml \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
-	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml
 
 Restart=no
 `),
@@ -135,7 +135,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.5.go
+++ b/pkg/setup/templates/1.5.go
@@ -41,7 +41,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--application-metrics-count-limit=50 \
 	--network-plugin=cni \
 	--cni-conf-dir={{.RootABSPath}}/net.d \
-	--cni-bin-dir={{.RootABSPath}}/bin \
+	--cni-bin-dir={{.RootABSPath}}/bin
 
 Restart=no
 `),
@@ -80,7 +80,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--watch-cache=false \
 	--watch-cache-sizes="" \
 	--deserialization-cache-size=0 \
-	--event-ttl=10m \
+	--event-ttl=10m
 
 Restart=no
 `),
@@ -105,7 +105,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.6.go
+++ b/pkg/setup/templates/1.6.go
@@ -44,7 +44,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--cgroup-driver={{ .CgroupDriver }} \
 	--network-plugin=cni \
 	--cni-conf-dir={{.RootABSPath}}/net.d \
-	--cni-bin-dir={{.RootABSPath}}/bin \
+	--cni-bin-dir={{.RootABSPath}}/bin
 
 Restart=no
 `),
@@ -83,7 +83,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--watch-cache=false \
 	--watch-cache-sizes="" \
 	--deserialization-cache-size=0 \
-	--event-ttl=10m \
+	--event-ttl=10m
 
 Restart=no
 `),
@@ -108,7 +108,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.7.go
+++ b/pkg/setup/templates/1.7.go
@@ -42,7 +42,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--application-metrics-count-limit=50 \
 	--network-plugin=cni \
 	--cni-conf-dir={{.RootABSPath}}/net.d \
-	--cni-bin-dir={{.RootABSPath}}/bin \
+	--cni-bin-dir={{.RootABSPath}}/bin
 
 Restart=no
 `),
@@ -81,7 +81,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--watch-cache=false \
 	--watch-cache-sizes="" \
 	--deserialization-cache-size=0 \
-	--event-ttl=10m \
+	--event-ttl=10m
 
 Restart=no
 `),
@@ -106,7 +106,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.8.go
+++ b/pkg/setup/templates/1.8.go
@@ -42,7 +42,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--application-metrics-count-limit=50 \
 	--network-plugin=cni \
 	--cni-conf-dir={{.RootABSPath}}/net.d \
-	--cni-bin-dir={{.RootABSPath}}/bin \
+	--cni-bin-dir={{.RootABSPath}}/bin
 
 Restart=no
 `),
@@ -84,7 +84,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--deserialization-cache-size=0 \
 	--audit-log-path={{.RootABSPath}}/logs/audit.log \
 	--audit-policy-file={{.RootABSPath}}/manifest-config/audit.yaml \
-	--event-ttl=10m \
+	--event-ttl=10m
 
 Restart=no
 `),
@@ -109,7 +109,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),

--- a/pkg/setup/templates/1.9.go
+++ b/pkg/setup/templates/1.9.go
@@ -44,7 +44,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube kubelet \
 	--cni-bin-dir={{.RootABSPath}}/bin \
 	--container-runtime={{.ContainerRuntime}} \
 	--runtime-request-timeout=15m \
-	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}} \
+	--container-runtime-endpoint=unix://{{.ContainerRuntimeEndpoint}}
 
 Restart=no
 `),
@@ -112,7 +112,7 @@ ExecStart={{.RootABSPath}}/bin/hyperkube apiserver \
 	--audit-policy-file={{.RootABSPath}}/manifest-config/audit.yaml \
 	--etcd-compaction-interval=0 \
 	--event-ttl=10m \
-	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml \
+	--admission-control-config-file={{.RootABSPath}}/manifest-config/admission.yaml
 
 Restart=no
 `),
@@ -137,7 +137,7 @@ ExecStart={{.RootABSPath}}/bin/etcd \
 	--client-cert-auth=true \
 	--trusted-ca-file={{.RootABSPath}}/secrets/etcd.issuing_ca \
 	--listen-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
-	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379,https://{{ .NodeIP }}:2379
 
 Restart=no
 `),


### PR DESCRIPTION
### What does this PR do?

Fix `ExecStart` directives in systemd unit files.

### Motivation

When testing on Ubuntu 19.04, I came accross this:

```
E0502 13:53:07.817833    7613 probe.go:50] Unexpected state of: unit "p8s-etcd.service" with load state "loaded" is "failed"
E0502 13:53:07.819015    7613 probe.go:50] Unexpected state of: unit "p8s-kubelet.service" with load state "loaded" is "failed"
```

Relevant journald logs show:
```
[p8s-etcd.service] error verifying flags, 'Restart=no' is not a valid flag. See 'etcd --help'.
[p8s-kubelet.service] F0502 13:53:05.893647    7807 server.go:154] unknown command: Restart=no
```

It looks like the syntax was off and systemd got less permissive.