### PR TITLE
Fix a race condition when downloading pupernetes

### DIFF
--- a/environments/container-linux/ignition.yaml
+++ b/environments/container-linux/ignition.yaml
@@ -30,6 +30,8 @@ systemd:
     contents: |
       [Unit]
       Description=Setup pupernetes
+      Wants=network-online.target
+      After=network-online.target
 
       [Service]
       Type=oneshot
@@ -93,7 +95,7 @@ storage:
     contents:
       inline: |
         #!/bin/bash -ex
-        curl -Lf https://github.com/DataDog/pupernetes/releases/download/v0.11.0/pupernetes -o /opt/bin/pupernetes
+        curl -Lf --retry 7 --retry-connrefused https://github.com/DataDog/pupernetes/releases/download/v0.11.0/pupernetes -o /opt/bin/pupernetes
         sha512sum -c /opt/bin/pupernetes.sha512sum
         chmod +x /opt/bin/pupernetes
 


### PR DESCRIPTION
### What does this PR do?

Fix a race condition when downloading pupernetes

### Motivation

It happens that from time to time, we see failures likes this:
```
 waiting for pupernetes binary to be in PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin ...
 + sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --wait-timeout 20m
 sudo: pupernetes: command not found
 + sleep 10
 + sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --wait-timeout 20m
 sudo: pupernetes: command not found
 + exit 1
Running after_script
00:01
Uploading artifacts for failed job
00:01
 ERROR: Job failed: exit code 1
```

### Additional Notes

Anything else we should know when reviewing?
