### PR TITLE
Indicate Linux is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ As pupernetes runs in [travis](./.travis.yml) and [circle-ci](./.circleci/config
 
 ### Runtime
 
+A Linux system is required.
+
 #### Executables
 
 * `tar`


### PR DESCRIPTION
I skimming the README I assumed that systemd was running *inside* k8s somehow, and didn't realize this required linux until I downloaded the binary and discovered that it's ELF!  In retrospect it was probably clear, but just to save the next person the momentary confusion..